### PR TITLE
Add proper dark mode support to homepage components

### DIFF
--- a/src/app/components/AboutBlurb.tsx
+++ b/src/app/components/AboutBlurb.tsx
@@ -15,7 +15,7 @@ export default async function AboutBlurb() {
   
   return (
     <div className="about-blurb my-4">
-      <p className="prose max-w-xl">{blurb ?? 'Loading...'}</p>
+      <p className="prose max-w-xl text-gray-900 dark:text-gray-100">{blurb ?? 'Loading...'}</p>
     </div>
   );
 }

--- a/src/app/components/FeedlyArticlesWidget.tsx
+++ b/src/app/components/FeedlyArticlesWidget.tsx
@@ -18,7 +18,7 @@ export default async function FeedlyArticlesWidget() {
   }
   
   if (!feedlyData || !feedlyData.articles || feedlyData.articles.length === 0) {
-    return <div className="feedly-widget p-4 bg-gray-100 rounded-lg">No articles available</div>;
+    return <div className="feedly-widget p-4 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-lg border border-gray-200 dark:border-gray-700">No articles available</div>;
   }
   
   // Get the latest 3 articles
@@ -27,7 +27,7 @@ export default async function FeedlyArticlesWidget() {
   // Use regular HTML with no framework-specific components for maximum compatibility
   return (
     <div className="feedly-widget mb-4">
-      <h3 className="text-lg font-semibold mb-3">Latest Reads</h3>
+      <h3 className="text-lg font-semibold mb-3 text-gray-900 dark:text-white">Latest Reads</h3>
       
       <div className="grid gap-4 md:grid-cols-3 sm:grid-cols-2 grid-cols-1">
         {latestArticles.map((article) => (
@@ -36,7 +36,7 @@ export default async function FeedlyArticlesWidget() {
             href={article.url} 
             target="_blank" 
             rel="noopener noreferrer"
-            className="article-card flex flex-col overflow-hidden rounded-lg border border-gray-200 transition-all hover:shadow-md"
+            className="article-card flex flex-col overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 transition-all hover:shadow-md"
           >
             {article.imageUrl ? (
               <div className="article-image h-40 overflow-hidden">
@@ -47,19 +47,19 @@ export default async function FeedlyArticlesWidget() {
                 />
               </div>
             ) : (
-              <div className="article-image-placeholder h-40 bg-gray-200 flex items-center justify-center">
-                <span className="text-gray-400">No image</span>
+              <div className="article-image-placeholder h-40 bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                <span className="text-gray-400 dark:text-gray-500">No image</span>
               </div>
             )}
             
             <div className="article-content p-4 flex-1 flex flex-col">
-              <h4 className="font-medium text-base line-clamp-2 mb-2">{article.title}</h4>
+              <h4 className="font-medium text-base line-clamp-2 mb-2 text-gray-900 dark:text-white">{article.title}</h4>
               
               {article.excerpt && (
-                <p className="text-sm text-gray-600 line-clamp-3 mb-3">{article.excerpt}</p>
+                <p className="text-sm text-gray-600 dark:text-gray-300 line-clamp-3 mb-3">{article.excerpt}</p>
               )}
               
-              <div className="article-meta mt-auto text-xs text-gray-500 flex justify-between items-center">
+              <div className="article-meta mt-auto text-xs text-gray-500 dark:text-gray-400 flex justify-between items-center">
                 <span>{new Date(article.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
                 {article.source && <span>{article.source}</span>}
               </div>

--- a/src/app/components/WeatherWidget.tsx
+++ b/src/app/components/WeatherWidget.tsx
@@ -16,7 +16,7 @@ export default async function WeatherWidget() {
   }
   
   if (!weatherData) {
-    return <div className="weather-widget p-4 bg-gray-100 rounded-lg">Weather data unavailable</div>;
+    return <div className="weather-widget p-4 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-300 rounded-lg">Weather data unavailable</div>;
   }
   
   // Choose icon based on weather condition
@@ -39,17 +39,17 @@ export default async function WeatherWidget() {
   };
   
   return (
-    <div className="weather-widget p-4 bg-gray-100 rounded-lg">
-      <h3 className="text-lg font-semibold">Weather in {weatherData.city}</h3>
+    <div className="weather-widget p-4 bg-gray-100 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Weather in {weatherData.city}</h3>
       <div className="flex items-center mt-2">
         <span className="text-3xl mr-3">{getWeatherIcon(weatherData.condition)}</span>
         <div className="flex-1">
-          <p className="font-medium text-lg">{Math.round(weatherData.temperature)}°F • {weatherData.condition}</p>
-          <p className="text-sm mt-1">Today: {formatTempRange()}</p>
+          <p className="font-medium text-lg text-gray-900 dark:text-white">{Math.round(weatherData.temperature)}°F • {weatherData.condition}</p>
+          <p className="text-sm mt-1 text-gray-600 dark:text-gray-300">Today: {formatTempRange()}</p>
         </div>
       </div>
       
-      <div className="mt-3 text-sm">
+      <div className="mt-3 text-sm text-gray-700 dark:text-gray-300">
         <p className="flex justify-between">
           <span>Humidity:</span> 
           <span className="font-medium">{weatherData.mean_humidity}% ({weatherData.humidity_classification})</span>


### PR DESCRIPTION
- Add dark:bg-gray-800 backgrounds to all widgets
- Add dark:text-white/gray-100/gray-300 text colors based on hierarchy
- Fix dark:border-gray-700 for better border contrast
- Ensure consistent styling across all components in dark mode
- Add background to article cards for better readability in dark mode