### PR TITLE
Add sizes attribute for article hero image

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -82,6 +82,7 @@ export default async function Page({ params }: Params) {
               alt={post.meta.title}
               fill
               priority
+              sizes="(max-width: 768px) 100vw, 768px"
               className="object-cover"
             />
           </div>


### PR DESCRIPTION
## Summary
- use `sizes` on article feature images to avoid delivering overly large images

## Testing
- `npx biome --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840d9600c548323b66ad7319ec2b328