### PR TITLE
Add case study pages from Notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The site also supports content management through Notion as a headless CMS:
 
 #### Nice-to-Haves / Next Up
 
-- [ ] **Add same functionality for case studies**  
+- [x] **Add same functionality for case studies**
   - Work on the case study page to add the same functionality as the article page
   - Work on the case study list page to add the same functionality as the article list page
 

--- a/src/app/case-studies/[slug]/loading.tsx
+++ b/src/app/case-studies/[slug]/loading.tsx
@@ -1,0 +1,35 @@
+export default function CaseStudyLoading() {
+  return (
+    <article className="max-w-3xl mx-auto py-8 px-4 animate-pulse">
+      <header className="mb-8">
+        {/* Feature image skeleton */}
+        <div className="mb-6 aspect-video relative rounded-lg overflow-hidden bg-gray-200" />
+
+        {/* Title skeleton */}
+        <div className="h-10 bg-gray-200 rounded w-3/4 mb-4" />
+
+        {/* Date skeleton */}
+        <div className="h-5 bg-gray-200 rounded w-48 mb-2" />
+
+        {/* Excerpt skeleton */}
+        <div className="h-6 bg-gray-200 rounded w-full" />
+      </header>
+
+      {/* Content skeleton */}
+      <div className="prose prose-lg max-w-none">
+        <div className="space-y-4">
+          <div className="h-4 bg-gray-200 rounded w-full" />
+          <div className="h-4 bg-gray-200 rounded w-5/6" />
+          <div className="h-4 bg-gray-200 rounded w-full" />
+          <div className="h-4 bg-gray-200 rounded w-4/5" />
+          <div className="h-32 bg-gray-200 rounded w-full my-6" />
+          <div className="h-4 bg-gray-200 rounded w-full" />
+          <div className="h-4 bg-gray-200 rounded w-3/4" />
+          <div className="h-4 bg-gray-200 rounded w-5/6" />
+          <div className="h-4 bg-gray-200 rounded w-full" />
+        </div>
+      </div>
+    </article>
+  );
+}
+

--- a/src/app/case-studies/page.tsx
+++ b/src/app/case-studies/page.tsx
@@ -1,23 +1,29 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import { listPosts, type PostMeta } from '../../../lib/providers/notion';
+import { getProxiedNotionImage } from '../../../lib/utils/notion-image';
 
-// Define local case study type for the component
-type CaseStudy = {
-  title: string;
-  slug: string;
-  date: string;
-  excerpt?: string;
-  featureImage: string; // Required field from TinaCMS
-};
+// Use the PostMeta type directly from the Notion provider
+type CaseStudy = PostMeta;
 
 export const metadata = {
   title: 'Case Studies | Jason Makes',
   description: 'Featured case studies showcasing design and development projects',
 };
 
-export default function CaseStudiesPage() {
-  // Temporary empty array - will be replaced with Sanity integration
-  const caseStudies: CaseStudy[] = [];
+// Force static generation - only revalidate via webhook
+export const dynamic = 'force-static';
+
+export default async function CaseStudiesPage() {
+  // Fetch case studies from Notion - this will be cached after build
+  const caseStudies = await listPosts({
+    filter: {
+      and: [
+        { property: 'Type', select: { equals: 'Case Study' } },
+        { property: 'Status', select: { equals: 'Published' } }
+      ]
+    }
+  });
 
   return (
     <main className="container mx-auto px-4 py-8">
@@ -27,12 +33,9 @@ export default function CaseStudiesPage() {
         <p>No case studies found. Check back soon!</p>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {caseStudies.filter(caseStudy => caseStudy !== null && caseStudy !== undefined)
-            .map((caseStudy) => {
-              // Safe to use type assertion after the filter
-              const validCaseStudy = caseStudy as CaseStudy;
-              return <CaseStudyCard key={validCaseStudy.slug} caseStudy={validCaseStudy} />;
-            })}
+          {caseStudies.map((caseStudy) => (
+            <CaseStudyCard key={caseStudy.slug} caseStudy={caseStudy} />
+          ))}
         </div>
       )}
     </main>
@@ -41,8 +44,8 @@ export default function CaseStudiesPage() {
 
 // Case study card component
 function CaseStudyCard({ caseStudy }: { caseStudy: CaseStudy }) {
-  const { title, slug, date, excerpt, featureImage } = caseStudy;
-  
+  const { title, slug, date, excerpt, feature } = caseStudy;
+
   // Format the date in a human-readable format
   const formattedDate = new Date(date).toLocaleDateString('en-US', {
     year: 'numeric',
@@ -50,18 +53,27 @@ function CaseStudyCard({ caseStudy }: { caseStudy: CaseStudy }) {
     day: 'numeric'
   });
 
+  // Get proxied image URL to avoid 403 errors
+  const imageUrl = getProxiedNotionImage(feature);
+
   return (
     <Link href={`/case-studies/${slug}`} className="block h-full">
       <div className="border rounded-lg overflow-hidden h-full flex flex-col hover:shadow-lg transition-shadow duration-300">
-        <div className="h-48 relative">
-          <Image 
-            src={featureImage}
-            alt={title}
-            fill
-            className="object-cover"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-          />
-        </div>
+        {imageUrl ? (
+          <div className="h-48 relative overflow-hidden">
+            <Image
+              src={imageUrl}
+              alt={title}
+              fill
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              className="object-cover transition-transform hover:scale-105 duration-300"
+            />
+          </div>
+        ) : (
+          <div className="h-48 bg-gray-200 flex items-center justify-center">
+            <span className="text-gray-400">No image</span>
+          </div>
+        )}
         <div className="p-4 flex-1 flex flex-col">
           <h2 className="text-xl font-semibold mb-2">{title}</h2>
           <p className="text-sm text-gray-500 mb-2">{formattedDate}</p>


### PR DESCRIPTION
## Summary
- load case studies from Notion just like articles
- render case study entries and details with Notion content
- add a loading skeleton for case study pages
- mark case study feature complete in README

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420a0f05148323aa20dfabe3eed8e8