### PR TITLE
Fix broken Notion images on local server

### DIFF
--- a/lib/utils/notion-image.ts
+++ b/lib/utils/notion-image.ts
@@ -7,13 +7,10 @@ export function getProxiedNotionImage(url: string | null | undefined): string | 
   
   // Only proxy Notion S3 URLs
   if (url.includes('amazonaws.com') && url.includes('X-Amz-')) {
-    // In production, use the API route proxy
-    if (process.env.NODE_ENV === 'production') {
-      return `/api/notion-image?url=${encodeURIComponent(url)}`;
-    }
+    return `/api/notion-image?url=${encodeURIComponent(url)}`;
   }
-  
-  // Return original URL for non-S3 images or in development
+
+  // Return original URL for non-S3 images
   return url;
 }
 


### PR DESCRIPTION
## Summary
- always proxy Notion S3 images through `/api/notion-image` regardless of environment

## Testing
- `pnpm install --frozen-lockfile` *(fails: GET https://registry.npmjs.org/... 403)*
- `pnpm lint` *(fails: biome: not found)*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843939f23208323a68e496efab80bcb