### PR TITLE
Improve dark mode for Notion content

### DIFF
--- a/src/app/articles/[slug]/loading.tsx
+++ b/src/app/articles/[slug]/loading.tsx
@@ -3,30 +3,30 @@ export default function ArticleLoading() {
       <article className="max-w-3xl mx-auto py-8 px-4 animate-pulse">
         <header className="mb-8">
           {/* Feature image skeleton */}
-          <div className="mb-6 aspect-video relative rounded-lg overflow-hidden bg-gray-200" />
+          <div className="mb-6 aspect-video relative rounded-lg overflow-hidden bg-gray-200 dark:bg-gray-700" />
           
           {/* Title skeleton */}
-          <div className="h-10 bg-gray-200 rounded w-3/4 mb-4" />
+          <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-4" />
           
           {/* Date skeleton */}
-          <div className="h-5 bg-gray-200 rounded w-48 mb-2" />
+          <div className="h-5 bg-gray-200 dark:bg-gray-700 rounded w-48 mb-2" />
           
           {/* Excerpt skeleton */}
-          <div className="h-6 bg-gray-200 rounded w-full" />
+          <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-full" />
         </header>
         
         {/* Content skeleton */}
-        <div className="prose prose-lg max-w-none">
+        <div className="prose prose-lg max-w-none dark:prose-invert">
           <div className="space-y-4">
-            <div className="h-4 bg-gray-200 rounded w-full" />
-            <div className="h-4 bg-gray-200 rounded w-5/6" />
-            <div className="h-4 bg-gray-200 rounded w-full" />
-            <div className="h-4 bg-gray-200 rounded w-4/5" />
-            <div className="h-32 bg-gray-200 rounded w-full my-6" />
-            <div className="h-4 bg-gray-200 rounded w-full" />
-            <div className="h-4 bg-gray-200 rounded w-3/4" />
-            <div className="h-4 bg-gray-200 rounded w-5/6" />
-            <div className="h-4 bg-gray-200 rounded w-full" />
+            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
+            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-5/6" />
+            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
+            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-4/5" />
+            <div className="h-32 bg-gray-200 dark:bg-gray-700 rounded w-full my-6" />
+            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
+            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
+            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-5/6" />
+            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
           </div>
         </div>
       </article>

--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -78,9 +78,9 @@ export default async function Page({ params }: Params) {
             />
           </div>
         )}
-        <h1 className="text-3xl md:text-4xl font-bold mb-4">{post.meta.title}</h1>
+        <h1 className="text-3xl md:text-4xl font-bold mb-4 text-gray-900 dark:text-gray-100">{post.meta.title}</h1>
         {post.meta.date && (
-          <p className="text-gray-600 mb-2">
+          <p className="text-gray-600 dark:text-gray-400 mb-2">
             {new Date(post.meta.date).toLocaleDateString('en-US', {
               year: 'numeric',
               month: 'long',
@@ -89,11 +89,11 @@ export default async function Page({ params }: Params) {
           </p>
         )}
         {post.meta.excerpt && (
-          <p className="text-xl text-gray-700">{post.meta.excerpt}</p>
+          <p className="text-xl text-gray-700 dark:text-gray-300">{post.meta.excerpt}</p>
         )}
       </header>
       
-      <div className="prose prose-lg max-w-none">
+      <div className="prose prose-lg max-w-none dark:prose-invert">
         {/* Render the Notion content blocks using client component */}
         <NotionClient recordMap={post.recordMap} />
       </div>

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -27,7 +27,7 @@ export default async function ArticlesPage() {
 
   return (
     <main className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">Articles</h1>
+      <h1 className="text-3xl font-bold mb-8 text-gray-900 dark:text-gray-100">Articles</h1>
       
       {articles.length === 0 ? (
         <p>No articles found. Check back soon!</p>
@@ -75,17 +75,17 @@ function ArticleCard({ article }: { article: Article }) {
             />
           </div>
         ) : (
-          <div className="h-48 bg-gray-200 flex items-center justify-center">
-            <span className="text-gray-400">No image</span>
+          <div className="h-48 bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+            <span className="text-gray-400 dark:text-gray-500">No image</span>
           </div>
         )}
         <div className="p-4 flex-1 flex flex-col">
           <h2 className="text-xl font-semibold mb-2">{title}</h2>
-          <p className="text-sm text-gray-500 mb-2">{formattedDate}</p>
-          {excerpt && <p className="mb-4 text-gray-700 flex-1">{excerpt}</p>}
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">{formattedDate}</p>
+          {excerpt && <p className="mb-4 text-gray-700 dark:text-gray-300 flex-1">{excerpt}</p>}
           
           <div className="mt-auto pt-4">
-            <span className="text-sm font-medium text-blue-600">Read more →</span>
+            <span className="text-sm font-medium text-blue-600 dark:text-blue-400">Read more →</span>
           </div>
         </div>
       </div>

--- a/src/app/case-studies/[slug]/loading.tsx
+++ b/src/app/case-studies/[slug]/loading.tsx
@@ -3,30 +3,30 @@ export default function CaseStudyLoading() {
     <article className="max-w-3xl mx-auto py-8 px-4 animate-pulse">
       <header className="mb-8">
         {/* Feature image skeleton */}
-        <div className="mb-6 aspect-video relative rounded-lg overflow-hidden bg-gray-200" />
+        <div className="mb-6 aspect-video relative rounded-lg overflow-hidden bg-gray-200 dark:bg-gray-700" />
         
         {/* Title skeleton */}
-        <div className="h-10 bg-gray-200 rounded w-3/4 mb-4" />
+        <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-4" />
         
         {/* Date skeleton */}
-        <div className="h-5 bg-gray-200 rounded w-48 mb-2" />
+        <div className="h-5 bg-gray-200 dark:bg-gray-700 rounded w-48 mb-2" />
         
         {/* Excerpt skeleton */}
-        <div className="h-6 bg-gray-200 rounded w-full" />
+        <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-full" />
       </header>
       
       {/* Content skeleton */}
-      <div className="prose prose-lg max-w-none">
+      <div className="prose prose-lg max-w-none dark:prose-invert">
         <div className="space-y-4">
-          <div className="h-4 bg-gray-200 rounded w-full" />
-          <div className="h-4 bg-gray-200 rounded w-5/6" />
-          <div className="h-4 bg-gray-200 rounded w-full" />
-          <div className="h-4 bg-gray-200 rounded w-4/5" />
-          <div className="h-32 bg-gray-200 rounded w-full my-6" />
-          <div className="h-4 bg-gray-200 rounded w-full" />
-          <div className="h-4 bg-gray-200 rounded w-3/4" />
-          <div className="h-4 bg-gray-200 rounded w-5/6" />
-          <div className="h-4 bg-gray-200 rounded w-full" />
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-5/6" />
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-4/5" />
+          <div className="h-32 bg-gray-200 dark:bg-gray-700 rounded w-full my-6" />
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-5/6" />
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
         </div>
       </div>
     </article>

--- a/src/app/case-studies/[slug]/page.tsx
+++ b/src/app/case-studies/[slug]/page.tsx
@@ -78,9 +78,9 @@ export default async function Page({ params }: Params) {
             />
           </div>
         )}
-        <h1 className="text-3xl md:text-4xl font-bold mb-4">{post.meta.title}</h1>
+        <h1 className="text-3xl md:text-4xl font-bold mb-4 text-gray-900 dark:text-gray-100">{post.meta.title}</h1>
         {post.meta.date && (
-          <p className="text-gray-600 mb-2">
+          <p className="text-gray-600 dark:text-gray-400 mb-2">
             {new Date(post.meta.date).toLocaleDateString('en-US', {
               year: 'numeric',
               month: 'long',
@@ -89,11 +89,11 @@ export default async function Page({ params }: Params) {
           </p>
         )}
         {post.meta.excerpt && (
-          <p className="text-xl text-gray-700">{post.meta.excerpt}</p>
+          <p className="text-xl text-gray-700 dark:text-gray-300">{post.meta.excerpt}</p>
         )}
       </header>
       
-      <div className="prose prose-lg max-w-none">
+      <div className="prose prose-lg max-w-none dark:prose-invert">
         {/* Render the Notion content blocks using client component */}
         <NotionClient recordMap={post.recordMap} />
       </div>

--- a/src/app/case-studies/page.tsx
+++ b/src/app/case-studies/page.tsx
@@ -27,7 +27,7 @@ export default async function CaseStudiesPage() {
 
   return (
     <main className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">Case Studies</h1>
+      <h1 className="text-3xl font-bold mb-8 text-gray-900 dark:text-gray-100">Case Studies</h1>
       
       {caseStudies.length === 0 ? (
         <p>No case studies found. Check back soon!</p>
@@ -75,17 +75,17 @@ function CaseStudyCard({ caseStudy }: { caseStudy: CaseStudy }) {
             />
           </div>
         ) : (
-          <div className="h-48 bg-gray-200 flex items-center justify-center">
-            <span className="text-gray-400">No image</span>
+          <div className="h-48 bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+            <span className="text-gray-400 dark:text-gray-500">No image</span>
           </div>
         )}
         <div className="p-4 flex-1 flex flex-col">
           <h2 className="text-xl font-semibold mb-2">{title}</h2>
-          <p className="text-sm text-gray-500 mb-2">{formattedDate}</p>
-          {excerpt && <p className="mb-4 text-gray-700 flex-1">{excerpt}</p>}
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">{formattedDate}</p>
+          {excerpt && <p className="mb-4 text-gray-700 dark:text-gray-300 flex-1">{excerpt}</p>}
           
           <div className="mt-auto pt-4">
-            <span className="text-sm font-medium text-blue-600">Read more →</span>
+            <span className="text-sm font-medium text-blue-600 dark:text-blue-400">Read more →</span>
           </div>
         </div>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  color-scheme: light dark;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,7 +28,7 @@ export default function Home() {
       
       {/* Below the fold - All widgets */}
       <section className="w-full bg-gray-50 dark:bg-gray-900 py-16 -mx-4 px-4">
-        <h2 className="text-3xl md:text-4xl font-bold mb-8">Daily Profile</h2>
+        <h2 className="text-3xl md:text-4xl font-bold mb-8 text-gray-900 dark:text-gray-100">Daily Profile</h2>
         
         {/* Weather and Spotify Widgets - side-by-side on desktop */}
         <div className="flex flex-col md:flex-row md:gap-6 mb-8">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -11,26 +11,26 @@ export default function Navigation() {
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between">
           <div className="mb-4 md:mb-0">
-            <Link href="/" className="text-xl font-semibold hover:text-blue-600 transition-colors">
+            <Link href="/" className="text-xl font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
               Jason Elgin
             </Link>
           </div>
           <ul className="flex space-x-8">
             <li>
-              <Link 
-                href="/articles" 
-                className={`hover:text-blue-600 transition-colors ${
-                  pathname?.startsWith('/articles') ? 'text-blue-600 font-medium' : ''
+              <Link
+                href="/articles"
+                className={`text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors ${
+                  pathname?.startsWith('/articles') ? 'text-blue-600 dark:text-blue-400 font-medium' : ''
                 }`}
               >
                 Articles
               </Link>
             </li>
             <li>
-              <Link 
-                href="/case-studies" 
-                className={`hover:text-blue-600 transition-colors ${
-                  pathname?.startsWith('/case-studies') ? 'text-blue-600 font-medium' : ''
+              <Link
+                href="/case-studies"
+                className={`text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors ${
+                  pathname?.startsWith('/case-studies') ? 'text-blue-600 dark:text-blue-400 font-medium' : ''
                 }`}
               >
                 Case Studies

--- a/src/components/NotionClient.tsx
+++ b/src/components/NotionClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { NotionRenderer } from 'react-notion-x'
 import { ExtendedRecordMap } from 'notion-types'
 import 'react-notion-x/src/styles.css'
@@ -13,13 +13,23 @@ export default function NotionClient({ recordMap }: { recordMap: ExtendedRecordM
   // This is just a stub for future implementation
   const components = {} as Record<string, React.ComponentType<any>>
 
+  const [darkMode, setDarkMode] = useState(false)
+
+  useEffect(() => {
+    const query = window.matchMedia('(prefers-color-scheme: dark)')
+    setDarkMode(query.matches)
+    const listener = (e: MediaQueryListEvent) => setDarkMode(e.matches)
+    query.addEventListener('change', listener)
+    return () => query.removeEventListener('change', listener)
+  }, [])
+
   return (
-    <div className="notion-renderer-wrapper prose max-w-none">
-      <NotionRenderer 
+    <div className="notion-renderer-wrapper prose max-w-none dark:prose-invert">
+      <NotionRenderer
         recordMap={recordMap}
         components={components}
-        fullPage={false} 
-        darkMode={false} // Set to false for now without theme integration
+        fullPage={false}
+        darkMode={darkMode}
         disableHeader
       />
     </div>


### PR DESCRIPTION
## Summary
- detect system dark mode in `NotionClient`
- invert article and case study body copy when dark
- add dark colors to article and case study loading skeletons

## Testing
- `pnpm lint` *(fails: biome not found)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ae02a7a88323a4c48b6ea716bfce