### PR TITLE
Add coverage for key utilities

### DIFF
--- a/__tests__/lib/profile.test.ts
+++ b/__tests__/lib/profile.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const weatherMock = vi.fn();
+const feedlyMock = vi.fn();
+const spotifyMock = vi.fn();
+
+vi.mock('../lib/providers/weather', () => ({ fetchWeather: weatherMock }));
+vi.mock('../lib/providers/feedly', () => ({ fetchFeedly: feedlyMock }));
+vi.mock('../lib/providers/spotify', () => ({ fetchSpotify: spotifyMock }));
+
+let buildProfile: typeof import('../lib/profile').buildProfile;
+
+const mockWeather = {
+  temperature: 70,
+  condition: 'Sunny',
+  city: 'Atlanta',
+  temperature_high: 75,
+  temperature_low: 65,
+  mean_humidity: 40,
+  precipitation_prob: 0,
+  humidity_classification: 'Comfortable'
+};
+const mockFeedly = { articles: [], lastUpdated: '' };
+const mockSpotify = { track: null, lastUpdated: '' };
+
+describe('buildProfile', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    weatherMock.mockResolvedValue(mockWeather);
+    feedlyMock.mockResolvedValue(mockFeedly);
+    spotifyMock.mockResolvedValue(mockSpotify);
+    process.env.NODE_ENV = 'development';
+    buildProfile = (await import('../lib/profile')).buildProfile;
+  });
+
+  it('uses in-memory cache in development', async () => {
+    await buildProfile();
+    expect(weatherMock).toHaveBeenCalledTimes(1);
+    await buildProfile();
+    expect(weatherMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back on weather error', async () => {
+    weatherMock.mockRejectedValueOnce(new Error('fail'));
+    const result = await buildProfile();
+    expect(result.weather.condition).toBe('Unknown');
+    expect(result.weather.city).toBe('Atlanta');
+  });
+});
+

--- a/__tests__/lib/providers/openai.test.ts
+++ b/__tests__/lib/providers/openai.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies used inside the provider
+const createMock = vi.fn();
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    chat: { completions: { create: createMock } }
+  }))
+}));
+
+vi.mock('../../../lib/kv', () => ({
+  kv: { get: vi.fn() }
+}));
+
+vi.mock('@vercel/edge-config', () => ({
+  get: vi.fn()
+}));
+
+import { kv } from '../../../lib/kv';
+import { get } from '@vercel/edge-config';
+import { generateBlurb } from '../../../lib/providers/openai';
+
+const baseProfile = {
+  weather: {
+    temperature: 70,
+    condition: 'Sunny',
+    city: 'Miami',
+    temperature_high: 75,
+    temperature_low: 65,
+    mean_humidity: 40,
+    precipitation_prob: 0,
+    humidity_classification: 'Comfortable'
+  },
+  feedly: { articles: [{ title: 'Article', url: '', date: 0, source: 'Src', excerpt: 'Ex' }], lastUpdated: '' },
+  spotify: { track: { title: 'Song', artist: 'Artist', album: '', coverUrl: '', trackUrl: '', playedAt: '' }, lastUpdated: '' }
+};
+
+describe('generateBlurb', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns OpenAI response when request succeeds', async () => {
+    createMock.mockResolvedValue({ choices: [{ message: { content: 'hi' } }] });
+    vi.mocked(get).mockResolvedValue('prompt');
+
+    const result = await generateBlurb(baseProfile as any, 50);
+    expect(result).toBe('hi');
+    expect(createMock).toHaveBeenCalled();
+  });
+
+  it('falls back to previous blurb from KV on error', async () => {
+    createMock.mockRejectedValue(new Error('fail'));
+    vi.mocked(kv.get).mockResolvedValue('old blurb');
+
+    const result = await generateBlurb(baseProfile as any, 50);
+    expect(result).toBe('old blurb');
+  });
+
+  it('uses default message when OpenAI and KV both fail', async () => {
+    createMock.mockRejectedValue(new Error('fail'));
+    vi.mocked(kv.get).mockResolvedValue(null);
+
+    const result = await generateBlurb(baseProfile as any, 50);
+    expect(result).toContain('Miami');
+  });
+});

--- a/__tests__/lib/providers/weather.test.ts
+++ b/__tests__/lib/providers/weather.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mapWeatherCodeToCondition } from '../../../lib/providers/weather';
+import { mapWeatherCodeToCondition, classifyHumidity } from '../../../lib/providers/weather';
 
 describe('Weather Provider', () => {
   describe('mapWeatherCodeToCondition', () => {
@@ -37,6 +37,20 @@ describe('Weather Provider', () => {
     it('should return "Unknown" for undefined weather codes', () => {
       expect(mapWeatherCodeToCondition(999)).toBe('Unknown');
       expect(mapWeatherCodeToCondition(-1)).toBe('Unknown');
+    });
+  });
+
+  describe('classifyHumidity', () => {
+    it('should categorize humidity ranges correctly', () => {
+      expect(classifyHumidity(0)).toBe('Dry');
+      expect(classifyHumidity(30)).toBe('Dry');
+      expect(classifyHumidity(31)).toBe('Comfortable');
+      expect(classifyHumidity(50)).toBe('Comfortable');
+      expect(classifyHumidity(55)).toBe('Somewhat Humid');
+      expect(classifyHumidity(70)).toBe('Somewhat Humid');
+      expect(classifyHumidity(75)).toBe('Humid');
+      expect(classifyHumidity(80)).toBe('Humid');
+      expect(classifyHumidity(81)).toBe('Muggy');
     });
   });
 });

--- a/__tests__/lib/utils/notion-image.test.ts
+++ b/__tests__/lib/utils/notion-image.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { getProxiedNotionImage, isNotionS3Url } from '../../../lib/utils/notion-image';
+
+describe('Notion image helpers', () => {
+  it('detects Notion S3 URLs', () => {
+    const s3 = 'https://s3.us-west-2.amazonaws.com/example.png?X-Amz-Signature=abc';
+    const other = 'https://example.com/image.png';
+    expect(isNotionS3Url(s3)).toBe(true);
+    expect(isNotionS3Url(other)).toBe(false);
+  });
+
+  it('proxies S3 URLs and leaves others intact', () => {
+    const s3 = 'https://s3.amazonaws.com/img.png?X-Amz-Signature=abc';
+    const other = 'https://example.com/img.png';
+    expect(getProxiedNotionImage(s3)).toBe(`/api/notion-image?url=${encodeURIComponent(s3)}`);
+    expect(getProxiedNotionImage(other)).toBe(other);
+  });
+
+  it('returns null when url is empty', () => {
+    expect(getProxiedNotionImage(null)).toBeNull();
+    expect(getProxiedNotionImage(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- extend weather tests to cover humidity classification
- add tests for Notion image utilities
- add tests for OpenAI blurb generator
- test profile builder caching and fallback logic

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b69f1b9083239945708ad6ad8c75