### PR TITLE
Refine navigation and profile data architecture

### DIFF
--- a/lib/config/navigation.ts
+++ b/lib/config/navigation.ts
@@ -1,0 +1,14 @@
+export type NavItem = {
+  label: string;
+  href: string;
+  /**
+   * Configure how the active state is calculated. Defaults to "startsWith"
+   * which works well for list pages that have nested routes.
+   */
+  match?: "exact" | "startsWith";
+};
+
+export const NAVIGATION_ITEMS: NavItem[] = [
+  { label: "Articles", href: "/articles" },
+  { label: "Case Studies", href: "/case-studies" },
+];

--- a/lib/config/site.ts
+++ b/lib/config/site.ts
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const siteMetadata: Metadata = {
+  title: "Jason Makes | Design & Development",
+  description:
+    "Jason Elgin's portfolio featuring articles and case studies about design and development",
+};
+
+export const NAVIGATION_TITLE = "jason | makes";

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -1,121 +1,125 @@
-import { fetchWeather } from './providers/weather';
-import type { Weather } from './providers/weather';
-// Phase 2: Feedly implementation
-import { fetchFeedly } from './providers/feedly';
-import type { FeedlyData } from './providers/feedly';
-// Phase 3: Spotify implementation
-import { fetchSpotify } from './providers/spotify';
+import type { FeedlyData } from "./providers/feedly";
+import { fetchFeedly } from "./providers/feedly";
+import { fetchSpotify } from "./providers/spotify";
+import type { Weather } from "./providers/weather";
+import { fetchWeather } from "./providers/weather";
 
-// Define the Profile type with implementations for current providers
 export type Profile = {
   weather: Weather;
   feedly: FeedlyData;
-  // Phase 3: Spotify integration
   spotify: Awaited<ReturnType<typeof fetchSpotify>>;
 };
 
-// In-memory cache for local development
-interface CacheEntry<T> {
+type CacheEntry<T> = {
   data: T;
   timestamp: number;
-}
+};
 
 const memoryCache: Record<string, CacheEntry<Profile>> = {};
+const DEFAULT_CACHE_DURATION_MS = 5 * 60 * 1000;
 
-// Cache duration in milliseconds (5 minutes by default, configurable via DEV_CACHE_MS env var)
-const CACHE_DURATION_MS = process.env.DEV_CACHE_MS ? Number.parseInt(process.env.DEV_CACHE_MS, 10) : 5 * 60 * 1000;
+const CACHE_DURATION_MS = (() => {
+  const rawValue = process.env.DEV_CACHE_MS;
+  const parsed = rawValue ? Number.parseInt(rawValue, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_CACHE_DURATION_MS;
+})();
 
-/**
- * Builds a complete profile by fetching data from all providers
- * Currently implements weather and Feedly (Phase 2)
- * Includes in-memory caching for development mode
- */
+function getFallbackWeather(): Weather {
+  return {
+    temperature: 75.5,
+    condition: "Unknown",
+    city: process.env.WEATHER_CITY || "Atlanta",
+    temperature_high: 80,
+    temperature_low: 65,
+    mean_humidity: 50,
+    precipitation_prob: 0,
+    humidity_classification: "Comfortable",
+  };
+}
+
+function getFallbackFeedly(): FeedlyData {
+  return {
+    articles: [
+      {
+        title: "Fallback Article",
+        url: "https://example.com/article",
+        date: Date.now() - 86_400_000,
+        source: "Example Source",
+      },
+    ],
+    lastUpdated: new Date().toISOString(),
+  };
+}
+
+function getFallbackSpotify(): Awaited<ReturnType<typeof fetchSpotify>> {
+  return {
+    track: null,
+    lastUpdated: new Date().toISOString(),
+  };
+}
+
+function logProviderError(provider: string, error: unknown) {
+  console.error(`[profile] ${provider} fetch failed:`, error);
+}
+
+function readCache(cacheKey: string): Profile | null {
+  const cacheEntry = memoryCache[cacheKey];
+  if (!cacheEntry) {
+    return null;
+  }
+
+  if (Date.now() - cacheEntry.timestamp < CACHE_DURATION_MS) {
+    return cacheEntry.data;
+  }
+
+  return null;
+}
+
+function writeCache(cacheKey: string, data: Profile) {
+  memoryCache[cacheKey] = {
+    data,
+    timestamp: Date.now(),
+  };
+}
+
 export async function buildProfile(): Promise<Profile> {
-  const isDev = process.env.NODE_ENV === 'development';
-  const cacheKey = 'profile-data';
-  
-  // Check cache in development mode
-  if (isDev && memoryCache[cacheKey]) {
-    const { data, timestamp } = memoryCache[cacheKey];
-    const now = Date.now();
-    
-    // Use cached data if it's still fresh
-    if (now - timestamp < CACHE_DURATION_MS) {
-      return data;
+  const isDev = process.env.NODE_ENV === "development";
+  const cacheKey = "profile-data";
+
+  if (isDev) {
+    const cached = readCache(cacheKey);
+    if (cached) {
+      return cached;
     }
   }
-  
-  // For Phase 2, we implement weather and feedly with individual error handling
-  // This ensures one failing provider won't cause the entire profile to fail
-  
-  // Fetch weather with error handling
-  let weather: Weather;
-  try {
-    const startTime = Date.now();
-    weather = await fetchWeather();
-  } catch (error) {
-    console.error('[DEV] Weather fetch failed:', error);
-    // Return minimal fallback weather data
-    weather = {
-      temperature: 75.5, // Fahrenheit fallback value
-      condition: 'Unknown',
-      city: process.env.WEATHER_CITY || 'Atlanta',
-      temperature_high: 80,
-      temperature_low: 65,
-      mean_humidity: 50,
-      precipitation_prob: 0,
-      humidity_classification: 'Comfortable'
-    };
-  }
-  
-  // Fetch Feedly with error handling
-  let feedly: FeedlyData;
-  try {
-    const startTime = Date.now();
-    feedly = await fetchFeedly();
-  } catch (error) {
-    console.error('[DEV] Feedly fetch failed:', error);
-    // Return minimal fallback Feedly data
-    feedly = {
-      articles: [
-        {
-          title: 'Fallback Article',
-          url: 'https://example.com/article',
-          date: Date.now() - 86400000, // Yesterday
-          source: 'Example Source'
-        }
-      ],
-      lastUpdated: new Date().toISOString()
-    };
-  }
-  
-  // Fetch Spotify with error handling
-  let spotify: Awaited<ReturnType<typeof fetchSpotify>>;
-  try {
-    const startTime = Date.now();
-    spotify = await fetchSpotify();
-  } catch (error) {
-    console.error('[DEV] Spotify fetch failed:', error);
-    // Return minimal fallback Spotify data
-    spotify = {
-      track: null,
-      lastUpdated: new Date().toISOString()
-    };
-  }
-  
-  const profileData: Profile = { 
+
+  const [weatherResult, feedlyResult, spotifyResult] = await Promise.allSettled([
+    fetchWeather(),
+    fetchFeedly(),
+    fetchSpotify(),
+  ]);
+
+  const weather = weatherResult.status === "fulfilled"
+    ? weatherResult.value
+    : (logProviderError("weather", weatherResult.reason), getFallbackWeather());
+
+  const feedly = feedlyResult.status === "fulfilled"
+    ? feedlyResult.value
+    : (logProviderError("feedly", feedlyResult.reason), getFallbackFeedly());
+
+  const spotify = spotifyResult.status === "fulfilled"
+    ? spotifyResult.value
+    : (logProviderError("spotify", spotifyResult.reason), getFallbackSpotify());
+
+  const profileData: Profile = {
     weather,
     feedly,
-    spotify
+    spotify,
   };
-  
-  // Cache the result in development mode
+
   if (isDev) {
-    memoryCache[cacheKey] = {
-      data: profileData,
-      timestamp: Date.now()
-    };
+    writeCache(cacheKey, profileData);
   }
-  
+
   return profileData;
 }

--- a/lib/utils/cn.ts
+++ b/lib/utils/cn.ts
@@ -1,0 +1,34 @@
+type ClassValue =
+  | string
+  | number
+  | false
+  | null
+  | undefined
+  | ClassValue[]
+  | { [key: string]: boolean | null | undefined };
+
+function toArray(value: ClassValue): Array<string | number> {
+  if (Array.isArray(value)) {
+    return value.flatMap(toArray);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.entries(value)
+      .filter(([, enabled]) => Boolean(enabled))
+      .map(([className]) => className);
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    return [value];
+  }
+
+  return [];
+}
+
+export function cn(...inputs: ClassValue[]): string {
+  return inputs
+    .flatMap(toArray)
+    .map((value) => value.toString().trim())
+    .filter(Boolean)
+    .join(" ");
+}

--- a/lib/utils/navigation.ts
+++ b/lib/utils/navigation.ts
@@ -1,0 +1,16 @@
+import type { NavItem } from "#lib/config/navigation";
+
+export function isNavItemActive(
+  pathname: string | null,
+  item: NavItem,
+): boolean {
+  if (!pathname) {
+    return false;
+  }
+
+  if (item.match === "exact") {
+    return pathname === item.href;
+  }
+
+  return pathname.startsWith(item.href);
+}

--- a/src/app/components/AboutBlurb.tsx
+++ b/src/app/components/AboutBlurb.tsx
@@ -1,21 +1,26 @@
-// app/components/AboutBlurb.tsx
 export const revalidate = 3600; // 1 hour (matches cron frequency)
 
-import { kv } from '../../../lib/kv';
+import { kv } from "#lib/kv";
 
 export default async function AboutBlurb() {
-  let blurb: string | null = null;
-  
   try {
-    // Fetch blurb from Vercel KV
-    blurb = await kv.get<string>('blurb');
+    const blurb = await kv.get<string>("blurb");
+
+    return (
+      <div className="about-blurb my-6">
+        <p className="prose max-w-xl text-xl italic leading-relaxed text-gray-900 dark:text-gray-100">
+          {blurb ?? "Loading..."}
+        </p>
+      </div>
+    );
   } catch (error) {
-    console.error('Failed to fetch blurb from KV:', error);
+    console.error("Failed to fetch blurb from KV:", error);
+    return (
+      <div className="about-blurb my-6">
+        <p className="prose max-w-xl text-xl italic leading-relaxed text-gray-900 dark:text-gray-100">
+          Loading...
+        </p>
+      </div>
+    );
   }
-  
-  return (
-    <div className="about-blurb my-6">
-      <p className="prose max-w-xl text-xl italic text-gray-900 dark:text-gray-100 leading-relaxed">{blurb ?? 'Loading...'}</p>
-    </div>
-  );
 }

--- a/src/app/components/FeedlyArticlesWidget.tsx
+++ b/src/app/components/FeedlyArticlesWidget.tsx
@@ -1,65 +1,70 @@
-// app/components/FeedlyArticlesWidget.tsx
 export const revalidate = 86_400; // 24 hours (daily refresh)
 
-import { kv } from '../../../lib/kv';
-import type { FeedlyData } from '../../../lib/providers/feedly';
+import type { Profile } from "#lib/profile";
+import { kv } from "#lib/kv";
+import type { FeedlyArticle, FeedlyData } from "#lib/providers/feedly";
 
-// Server component that fetches data
+type FeedlyProfile = Pick<Profile, "feedly">;
+
+function selectLatestArticles(data: FeedlyData): FeedlyArticle[] {
+  return data.articles.slice(0, 3);
+}
 
 export default async function FeedlyArticlesWidget() {
   let feedlyData: FeedlyData | null = null;
-  
+
   try {
-    // Fetch profile data from Vercel KV
-    const profile = await kv.get('profile') as { feedly: FeedlyData } | null;
-    feedlyData = profile?.feedly || null;
+    const profile = await kv.get<FeedlyProfile>("profile");
+    feedlyData = profile?.feedly ?? null;
   } catch (error) {
-    console.error('Failed to fetch Feedly data from KV:', error);
+    console.error("Failed to fetch Feedly data from KV:", error);
   }
-  
-  if (!feedlyData || !feedlyData.articles || feedlyData.articles.length === 0) {
-    return <div className="feedly-widget p-4 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-lg border border-gray-200 dark:border-gray-700">No articles available</div>;
+
+  const latestArticles = feedlyData ? selectLatestArticles(feedlyData) : [];
+
+  if (latestArticles.length === 0) {
+    return (
+      <div className="feedly-widget rounded-lg border border-gray-200 bg-gray-100 p-4 text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+        No articles available
+      </div>
+    );
   }
-  
-  // Get the latest 3 articles
-  const latestArticles = feedlyData.articles.slice(0, 3);
-  
-  // Use regular HTML with no framework-specific components for maximum compatibility
+
   return (
     <div className="feedly-widget mb-4">
-      <h3 className="text-lg font-semibold mb-3 text-gray-900 dark:text-white">Latest Reads</h3>
-      
-      <div className="grid gap-4 md:grid-cols-3 sm:grid-cols-2 grid-cols-1">
+      <h3 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Latest Reads</h3>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
         {latestArticles.map((article) => (
-          <a 
-            key={article.url || `article-${article.date}-${article.title}`} 
-            href={article.url} 
-            target="_blank" 
+          <a
+            key={article.url || `article-${article.date}-${article.title}`}
+            href={article.url}
+            target="_blank"
             rel="noopener noreferrer"
-            className="article-card flex flex-col overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 transition-all hover:shadow-md"
+            className="article-card flex h-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white transition-all hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
           >
             {article.imageUrl ? (
               <div className="article-image h-40 overflow-hidden">
-                <img 
-                  src={article.imageUrl} 
-                  alt={article.title} 
-                  className="w-full h-full object-cover"
+                <img
+                  src={article.imageUrl}
+                  alt={article.title}
+                  className="h-full w-full object-cover"
                 />
               </div>
             ) : (
-              <div className="article-image-placeholder h-40 bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+              <div className="article-image-placeholder flex h-40 items-center justify-center bg-gray-200 dark:bg-gray-700">
                 <span className="text-gray-400 dark:text-gray-500">No image</span>
               </div>
             )}
-            
-            <div className="article-content p-4 flex-1 flex flex-col">
-              <h4 className="font-medium text-base line-clamp-2 mb-2 text-gray-900 dark:text-white">{article.title}</h4>
-              
+
+            <div className="article-content flex flex-1 flex-col p-4">
+              <h4 className="mb-2 line-clamp-2 text-base font-medium text-gray-900 dark:text-white">{article.title}</h4>
+
               {article.excerpt && (
-                <p className="text-sm text-gray-600 dark:text-gray-300 line-clamp-3 mb-3">{article.excerpt}</p>
+                <p className="mb-3 line-clamp-3 text-sm text-gray-600 dark:text-gray-300">{article.excerpt}</p>
               )}
-              
-              <div className="article-meta mt-auto text-xs text-gray-500 dark:text-gray-400 flex justify-end items-center">
+
+              <div className="article-meta mt-auto flex items-center justify-end text-xs text-gray-500 dark:text-gray-400">
                 {article.source && <span>{article.source}</span>}
               </div>
             </div>

--- a/src/app/components/SpotifyWidget.tsx
+++ b/src/app/components/SpotifyWidget.tsx
@@ -1,43 +1,43 @@
-// app/components/SpotifyWidget.tsx
 export const revalidate = 3600; // 1 hour (matches cron frequency)
 
-import { kv } from '../../../lib/kv';
-import type { SpotifyTrack } from '../../../lib/providers/spotify';
+import type { Profile } from "#lib/profile";
+import { kv } from "#lib/kv";
+import type { SpotifyTrack } from "#lib/providers/spotify";
+
+type SpotifyProfile = Pick<Profile, "spotify">;
 
 export default async function SpotifyWidget() {
   let trackData: SpotifyTrack | null = null;
-  // Track last updated timestamp for future use if needed
-  
+
   try {
-    // Fetch profile data from Vercel KV
-    const profile = await kv.get('profile') as { spotify?: { track: SpotifyTrack | null, lastUpdated: string } } | null;
-    trackData = profile?.spotify?.track || null;
-    // We could track lastUpdated here if needed in the future
+    const profile = await kv.get<SpotifyProfile>("profile");
+    trackData = profile?.spotify.track ?? null;
   } catch (error) {
-    console.error('Failed to fetch Spotify data from KV:', error);
+    console.error("Failed to fetch Spotify data from KV:", error);
   }
-  
+
   if (!trackData) {
-    return <div className="spotify-widget p-4 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-300 rounded-lg">Music data unavailable</div>;
+    return (
+      <div className="spotify-widget rounded-lg border border-gray-200 bg-gray-100 p-4 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+        Music data unavailable
+      </div>
+    );
   }
-  
-  
+
   return (
-    <div className="spotify-widget p-4 bg-gray-100 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+    <div className="spotify-widget rounded-lg border border-gray-200 bg-gray-100 p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
       <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Recently Played</h3>
-      <div className="flex items-center mt-2">
-        <span className="text-3xl mr-3">🎵</span>
+      <div className="mt-2 flex items-center">
+        <span className="mr-3 text-3xl">🎵</span>
         <div className="flex-1">
-          <p className="font-medium text-lg text-gray-900 dark:text-white">{trackData.title}</p>
-          <p className="text-sm mt-1 text-gray-600 dark:text-gray-300">
-            by {trackData.artist}
-          </p>
+          <p className="text-lg font-medium text-gray-900 dark:text-white">{trackData.title}</p>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">by {trackData.artist}</p>
           {trackData.trackUrl && (
-            <a 
-              href={trackData.trackUrl} 
-              target="_blank" 
+            <a
+              href={trackData.trackUrl}
+              target="_blank"
               rel="noopener noreferrer"
-              className="inline-block mt-2 text-xs text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
+              className="mt-2 inline-block text-xs text-green-600 transition-colors hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
             >
               Listen on Spotify →
             </a>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,12 @@ import type { Metadata } from "next";
 import { Geist_Mono, Instrument_Sans } from "next/font/google";
 import localFont from "next/font/local";
 import { Analytics } from "@vercel/analytics/react";
+
+import { siteMetadata } from "#lib/config/site";
+
+import Navigation from "@/components/Navigation";
+
 import "./globals.css";
-import Navigation from "../components/Navigation";
 
 // Load Apoc Normal Bold font from local file
 const apocFont = localFont({
@@ -28,10 +32,7 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-export const metadata: Metadata = {
-  title: "Jason Makes | Design & Development",
-  description: "Jason Elgin's portfolio featuring articles and case studies about design and development",
-};
+export const metadata: Metadata = siteMetadata;
 
 export default function RootLayout({
   children,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
-import WeatherWidget from './components/WeatherWidget';
-import AboutBlurb from './components/AboutBlurb';
-import FeedlyArticlesWidget from './components/FeedlyArticlesWidget';
-import SpotifyWidget from './components/SpotifyWidget';
+import WeatherWidget from "@/app/components/WeatherWidget";
+import AboutBlurb from "@/app/components/AboutBlurb";
+import FeedlyArticlesWidget from "@/app/components/FeedlyArticlesWidget";
+import SpotifyWidget from "@/app/components/SpotifyWidget";
 
 export default function Home() {
   return (

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,41 +1,42 @@
-'use client';
+"use client";
 
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { NAVIGATION_TITLE } from "#lib/config/site";
+import { NAVIGATION_ITEMS } from "#lib/config/navigation";
+import { cn } from "#lib/utils/cn";
+import { isNavItemActive } from "#lib/utils/navigation";
 
 export default function Navigation() {
   const pathname = usePathname();
-  
+
   return (
     <nav className="py-6 mb-8">
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between">
           <div className="mb-4 md:mb-0">
-            <Link href="/" className="text-xl font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
-              jason | makes
+            <Link
+              href="/"
+              className="text-xl font-semibold text-gray-900 transition-colors hover:text-blue-600 dark:text-gray-100 dark:hover:text-blue-400"
+            >
+              {NAVIGATION_TITLE}
             </Link>
           </div>
           <ul className="flex space-x-8">
-            <li>
-              <Link
-                href="/articles"
-                className={`text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors ${
-                  pathname?.startsWith('/articles') ? 'text-blue-600 dark:text-blue-400 font-medium' : ''
-                }`}
-              >
-                Articles
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/case-studies"
-                className={`text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors ${
-                  pathname?.startsWith('/case-studies') ? 'text-blue-600 dark:text-blue-400 font-medium' : ''
-                }`}
-              >
-                Case Studies
-              </Link>
-            </li>
+            {NAVIGATION_ITEMS.map((item) => (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  className={cn(
+                    "text-gray-900 transition-colors hover:text-blue-600 dark:text-gray-100 dark:hover:text-blue-400",
+                    isNavItemActive(pathname, item) && "font-medium text-blue-600 dark:text-blue-400",
+                  )}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            ))}
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- centralize site metadata and navigation links for reuse across the app
- refactor widgets to consume typed profile slices from KV with clearer fallbacks
- make profile aggregation concurrent with shared caching helpers for better resilience

## Testing
- pnpm lint *(fails: existing formatting/organize-imports violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e03adfd79c8323914038cb553676ad