### PR TITLE
Add update timestamps to homepage widgets

### DIFF
--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -34,10 +34,11 @@ function seedMockData() {
       
       // Sample weather data
       const sampleWeather = {
-        temperature: 75.5, 
+        temperature: 75.5,
         condition: 'Partly Cloudy',
         city: process.env.WEATHER_CITY || 'Atlanta',
-        
+        lastUpdated: new Date().toISOString(),
+
         // Enhanced data fields
         temperature_high: 84.2,
         temperature_low: 62.8,

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -29,6 +29,7 @@ function getFallbackWeather(): Weather {
     temperature: 75.5,
     condition: "Unknown",
     city: process.env.WEATHER_CITY || "Atlanta",
+    lastUpdated: new Date().toISOString(),
     temperature_high: 80,
     temperature_low: 65,
     mean_humidity: 50,

--- a/lib/providers/weather.ts
+++ b/lib/providers/weather.ts
@@ -8,7 +8,8 @@ export interface Weather {
   temperature: number;         // Current temperature
   condition: string;           // Weather condition description
   city: string;                // City name from environment variables
-  
+  lastUpdated: string;         // ISO timestamp for when the data was fetched
+
   // Enhanced data points
   temperature_high: number;    // Daily high temperature
   temperature_low: number;     // Daily low temperature
@@ -89,7 +90,8 @@ export async function fetchWeather(): Promise<Weather> {
       temperature: data.current.temperature_2m,
       condition,
       city: cityName,
-      
+      lastUpdated: new Date().toISOString(),
+
       // Enhanced data points
       temperature_high: data.daily.temperature_2m_max[0],
       temperature_low: data.daily.temperature_2m_min[0],
@@ -120,7 +122,8 @@ export async function fetchWeather(): Promise<Weather> {
       temperature: 75.5, // Fahrenheit fallback value
       condition: 'Unknown',
       city: cityName,
-      
+      lastUpdated: new Date().toISOString(),
+
       // Enhanced fallback data
       temperature_high: 80,
       temperature_low: 65,

--- a/src/app/api/cron/update-profile/route.ts
+++ b/src/app/api/cron/update-profile/route.ts
@@ -101,6 +101,7 @@ async function createResilientProfile(logger: Logger, timeoutMs = 10000) {
           temperature: 72,
           condition: 'Unknown',
           city: process.env.WEATHER_CITY || 'Atlanta',
+          lastUpdated: new Date().toISOString(),
           temperature_high: 80,
           temperature_low: 60,
           precipitation_prob: 0,

--- a/src/app/api/cron/update-profile/utils.ts
+++ b/src/app/api/cron/update-profile/utils.ts
@@ -84,7 +84,8 @@ export async function createResilientProfile(timeoutMs = 5000) {
         temperature: 75.5, // Fahrenheit fallback value
         condition: 'Unknown',
         city: process.env.WEATHER_CITY || 'Atlanta',
-        
+        lastUpdated: new Date().toISOString(),
+
         // Enhanced fallback data
         temperature_high: 80,
         temperature_low: 65,

--- a/src/app/components/FeedlyArticlesWidget.tsx
+++ b/src/app/components/FeedlyArticlesWidget.tsx
@@ -3,6 +3,7 @@ export const revalidate = 86_400; // 24 hours (daily refresh)
 import type { Profile } from "#lib/profile";
 import { kv } from "#lib/kv";
 import type { FeedlyArticle, FeedlyData } from "#lib/providers/feedly";
+import { formatUpdatedAt } from "@/lib/date";
 
 type FeedlyProfile = Pick<Profile, "feedly">;
 
@@ -32,7 +33,12 @@ export default async function FeedlyArticlesWidget() {
 
   return (
     <div className="feedly-widget mb-4">
-      <h3 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Latest Reads</h3>
+      <div className="mb-3 flex flex-col gap-1 text-gray-500 dark:text-gray-400 sm:flex-row sm:items-center sm:justify-between">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Latest Reads</h3>
+        {feedlyData?.lastUpdated && (
+          <span className="text-xs">Updated {formatUpdatedAt(feedlyData.lastUpdated)}</span>
+        )}
+      </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
         {latestArticles.map((article) => (

--- a/src/app/components/SpotifyWidget.tsx
+++ b/src/app/components/SpotifyWidget.tsx
@@ -3,15 +3,18 @@ export const revalidate = 3600; // 1 hour (matches cron frequency)
 import type { Profile } from "#lib/profile";
 import { kv } from "#lib/kv";
 import type { SpotifyTrack } from "#lib/providers/spotify";
+import { formatUpdatedAt } from "@/lib/date";
 
 type SpotifyProfile = Pick<Profile, "spotify">;
 
 export default async function SpotifyWidget() {
+  let spotifyData: SpotifyProfile["spotify"] | null = null;
   let trackData: SpotifyTrack | null = null;
 
   try {
     const profile = await kv.get<SpotifyProfile>("profile");
-    trackData = profile?.spotify.track ?? null;
+    spotifyData = profile?.spotify ?? null;
+    trackData = spotifyData?.track ?? null;
   } catch (error) {
     console.error("Failed to fetch Spotify data from KV:", error);
   }
@@ -19,7 +22,12 @@ export default async function SpotifyWidget() {
   if (!trackData) {
     return (
       <div className="spotify-widget rounded-lg border border-gray-200 bg-gray-100 p-4 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-        Music data unavailable
+        <p>Music data unavailable</p>
+        {spotifyData?.lastUpdated && (
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            Updated {formatUpdatedAt(spotifyData.lastUpdated)}
+          </p>
+        )}
       </div>
     );
   }
@@ -44,6 +52,11 @@ export default async function SpotifyWidget() {
           )}
         </div>
       </div>
+      {spotifyData?.lastUpdated && (
+        <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">
+          Updated {formatUpdatedAt(spotifyData.lastUpdated)}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/app/components/WeatherWidget.tsx
+++ b/src/app/components/WeatherWidget.tsx
@@ -3,6 +3,7 @@ export const revalidate = 3600; // 1 hour (matches cron frequency)
 import type { Profile } from "#lib/profile";
 import { kv } from "#lib/kv";
 import type { Weather } from "#lib/providers/weather";
+import { formatUpdatedAt } from "@/lib/date";
 
 type WeatherProfile = Pick<Profile, "weather">;
 
@@ -66,6 +67,10 @@ export default async function WeatherWidget() {
           <dd className="font-medium">{weatherData.precipitation_prob}%</dd>
         </div>
       </dl>
+
+      <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">
+        Updated {formatUpdatedAt(weatherData.lastUpdated)}
+      </p>
     </div>
   );
 }

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,25 @@
+export function formatUpdatedAt(isoString: string | null | undefined): string {
+  if (!isoString) {
+    return "Unknown";
+  }
+
+  const parsedDate = new Date(isoString);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return "Unknown";
+  }
+
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone: "America/New_York",
+      timeZoneName: "short",
+    }).format(parsedDate);
+  } catch (error) {
+    console.error("Failed to format date in Eastern Time:", error);
+    return "Unknown";
+  }
+}


### PR DESCRIPTION
## Summary
- add `lastUpdated` metadata to weather data and ensure fallbacks provide it
- display formatted update timestamps on the weather, feedly, and spotify homepage widgets
- add a shared date formatter helper for consistent timestamp rendering
- render widget update timestamps in Eastern Time for consistent presentation

## Testing
- pnpm lint *(fails: existing Biome formatting/style issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e06409a5388323a7b24942a2beab2c