### PR TITLE
Variation A — “Shoreline”: refined seascape aesthetic across the site

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -24,7 +24,7 @@ export default function AboutPage() {
     <PageShell>
       <section className="container mx-auto px-4 py-14 md:py-20">
         <div className="tide-rise max-w-3xl">
-          <p className="eyebrow mb-3">Product · Design · Code</p>
+          <p className="eyebrow mb-3">Atlanta · Product · Design</p>
           <h1 className="page-title text-4xl md:text-5xl lg:text-6xl">
             Jason Elgin
           </h1>
@@ -55,10 +55,10 @@ export default function AboutPage() {
 
           <div className="mt-8 space-y-5 text-lg leading-relaxed text-[var(--ink)]">
             <p>
-              I'm a product designer and builder with more than 15 years shaping
-              software people actually understand. Today I lead product at
-              Standard Education, turning K–12 analytics into tools that help
-              educators reach students before they fall behind.
+              I'm an Atlanta-based product designer and builder with more than
+              15 years shaping software people actually understand. Today I lead
+              product at Standard Education, turning K–12 analytics into tools
+              that help educators reach students before they fall behind.
             </p>
             <p>
               Before that I designed growth and collaboration at FullStory,
@@ -97,8 +97,8 @@ export default function AboutPage() {
             Daily Profile
           </h2>
           <p className="lede mt-2 max-w-xl">
-            A small, automatically-updating snapshot — the local weather, what
-            I've been listening to, and what I've been reading.
+            A small, automatically-updating snapshot — the weather over Atlanta,
+            what I've been listening to, and what I've been reading.
           </p>
 
           <div className="mt-8 grid gap-6 md:grid-cols-2">

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,11 @@
+import Link from "next/link";
+
 import AboutBlurb from "@/app/components/AboutBlurb";
 import FeedlyArticlesWidget from "@/app/components/FeedlyArticlesWidget";
 import SpotifyWidget from "@/app/components/SpotifyWidget";
 import WeatherWidget from "@/app/components/WeatherWidget";
+import PageShell from "@/components/PageShell";
+import WaveRule from "@/components/WaveRule";
 
 export const metadata = {
   title: "About | Jason Makes",
@@ -9,23 +13,29 @@ export const metadata = {
     "About Jason Elgin, product leader and designer building tools for education, analytics, and creative work.",
 };
 
+const elsewhere = [
+  { label: "GitHub", href: "https://github.com/jrelgin" },
+  { label: "Email", href: "mailto:jason@signallantern.com" },
+  { label: "Signal Lantern", href: "https://signallantern.com" },
+];
+
 export default function AboutPage() {
   return (
-    <>
-      <section className="container mx-auto flex min-h-[calc(100vh-7rem)] flex-col px-4">
-        <div className="flex-grow" />
-
-        <div className="max-w-6xl">
-          <h1 className="text-2xl font-medium leading-relaxed text-gray-800 dark:text-gray-200 md:text-3xl lg:text-4xl">
-            Head of Product at Standard Education
+    <PageShell>
+      <section className="container mx-auto px-4 py-14 md:py-20">
+        <div className="tide-rise max-w-3xl">
+          <p className="eyebrow mb-3">Boston · Product &amp; Design</p>
+          <h1 className="page-title text-4xl md:text-5xl lg:text-6xl">
+            Jason Elgin
           </h1>
-          <p className="font-body mt-2 text-xl font-normal leading-normal text-[var(--color-gray-500)] dark:text-gray-400 md:text-2xl lg:text-2xl">
-            Previously product design and strategy at{" "}
+          <p className="lede mt-4 text-xl md:text-2xl">
+            Head of Product at Standard Education. Previously product design and
+            strategy at{" "}
             <a
               href="https://signallantern.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="underline transition-colors hover:text-gray-800 dark:hover:text-gray-300"
+              className="text-[var(--accent)] underline decoration-1 underline-offset-4 transition-colors hover:text-[var(--accent-strong)]"
             >
               Signal Lantern
             </a>{" "}
@@ -34,45 +44,79 @@ export default function AboutPage() {
               href="https://fullstory.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="underline transition-colors hover:text-gray-800 dark:hover:text-gray-300"
+              className="text-[var(--accent)] underline decoration-1 underline-offset-4 transition-colors hover:text-[var(--accent-strong)]"
             >
               FullStory
             </a>
+            .
           </p>
+
+          <WaveRule className="mt-8 max-w-[11rem] opacity-80" />
+
+          <div className="mt-8 space-y-5 text-lg leading-relaxed text-[var(--ink)]">
+            <p>
+              I'm a product designer and builder with more than 15 years shaping
+              software people actually understand. Today I lead product at
+              Standard Education, turning K–12 analytics into tools that help
+              educators reach students before they fall behind.
+            </p>
+            <p>
+              Before that I designed growth and collaboration at FullStory,
+              research tooling at Glass, and product strategy at Signal Lantern.
+              I care about mission-driven work, systems that stay simple as they
+              scale, and interfaces that respect the person on the other side of
+              the screen.
+            </p>
+          </div>
+
+          <ul className="mt-8 flex flex-wrap gap-x-6 gap-y-2 font-mono text-xs uppercase tracking-wider">
+            {elsewhere.map((item) => (
+              <li key={item.label}>
+                <a
+                  href={item.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[var(--ink-muted)] transition-colors hover:text-[var(--accent)]"
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
         </div>
 
-        <div className="flex-grow" />
-
-        <div className="ml-auto max-w-md pb-8">
+        <div className="tide-rise tide-rise-1 mt-10 max-w-3xl">
           <AboutBlurb />
         </div>
       </section>
 
-      <section className="w-full bg-gray-50 py-16 dark:bg-gray-900">
-        <div className="container mx-auto px-4">
-          <h2 className="mb-8 text-3xl font-bold text-gray-900 dark:text-gray-100 md:text-4xl">
+      <section className="border-t border-[var(--hairline)]">
+        <div className="container mx-auto px-4 py-14 md:py-16">
+          <p className="eyebrow mb-2">Right now</p>
+          <h2 className="font-heading text-3xl text-[var(--ink-strong)] md:text-4xl">
             Daily Profile
           </h2>
+          <p className="lede mt-2 max-w-xl">
+            A small, automatically-updating snapshot — the weather over Boston,
+            what I've been listening to, and what I've been reading.
+          </p>
 
-          <div className="mb-8 flex flex-col md:flex-row md:gap-6">
-            <div className="mb-6 w-full md:mb-0 md:w-1/2">
-              <WeatherWidget />
-            </div>
-
-            <div className="w-full md:w-1/2">
-              <SpotifyWidget />
-            </div>
+          <div className="mt-8 grid gap-6 md:grid-cols-2">
+            <WeatherWidget />
+            <SpotifyWidget />
           </div>
 
-          <div className="mt-8">
+          <div className="mt-6">
             <FeedlyArticlesWidget />
           </div>
         </div>
       </section>
 
-      <footer className="py-6 text-center">
-        <p>&copy; {new Date().getFullYear()}</p>
+      <footer className="container mx-auto px-4 py-10">
+        <p className="font-mono text-xs uppercase tracking-wider text-[var(--ink-muted)]">
+          © {new Date().getFullYear()} Jason Elgin
+        </p>
       </footer>
-    </>
+    </PageShell>
   );
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -24,7 +24,7 @@ export default function AboutPage() {
     <PageShell>
       <section className="container mx-auto px-4 py-14 md:py-20">
         <div className="tide-rise max-w-3xl">
-          <p className="eyebrow mb-3">Boston · Product &amp; Design</p>
+          <p className="eyebrow mb-3">Product · Design · Code</p>
           <h1 className="page-title text-4xl md:text-5xl lg:text-6xl">
             Jason Elgin
           </h1>
@@ -97,8 +97,8 @@ export default function AboutPage() {
             Daily Profile
           </h2>
           <p className="lede mt-2 max-w-xl">
-            A small, automatically-updating snapshot — the weather over Boston,
-            what I've been listening to, and what I've been reading.
+            A small, automatically-updating snapshot — the local weather, what
+            I've been listening to, and what I've been reading.
           </p>
 
           <div className="mt-8 grid gap-6 md:grid-cols-2">

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link";
-
 import AboutBlurb from "@/app/components/AboutBlurb";
 import FeedlyArticlesWidget from "@/app/components/FeedlyArticlesWidget";
 import SpotifyWidget from "@/app/components/SpotifyWidget";
@@ -17,6 +15,7 @@ const elsewhere = [
   { label: "GitHub", href: "https://github.com/jrelgin" },
   { label: "Email", href: "mailto:jason@signallantern.com" },
   { label: "Signal Lantern", href: "https://signallantern.com" },
+  { label: "FullStory", href: "https://fullstory.com" },
 ];
 
 export default function AboutPage() {
@@ -24,48 +23,62 @@ export default function AboutPage() {
     <PageShell>
       <section className="container mx-auto px-4 py-14 md:py-20">
         <div className="tide-rise max-w-3xl">
-          <p className="eyebrow mb-3">Atlanta · Product · Design</p>
+          <p className="eyebrow mb-3">Product builder</p>
           <h1 className="page-title text-4xl md:text-5xl lg:text-6xl">
             Jason Elgin
           </h1>
           <p className="lede mt-4 text-xl md:text-2xl">
-            Head of Product at Standard Education. Previously product design and
-            strategy at{" "}
-            <a
-              href="https://signallantern.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--accent)] underline decoration-1 underline-offset-4 transition-colors hover:text-[var(--accent-strong)]"
-            >
-              Signal Lantern
-            </a>{" "}
-            and{" "}
-            <a
-              href="https://fullstory.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--accent)] underline decoration-1 underline-offset-4 transition-colors hover:text-[var(--accent-strong)]"
-            >
-              FullStory
-            </a>
-            .
+            Head of Product at Standard Education, after fifteen years of
+            turning messy problems into software that works.
           </p>
 
           <WaveRule className="mt-8 max-w-[11rem] opacity-80" />
 
-          <div className="mt-8 space-y-5 text-lg leading-relaxed text-[var(--ink)]">
+          <div className="mt-8 max-w-2xl space-y-5 text-lg leading-relaxed text-[var(--ink)]">
             <p>
-              I'm an Atlanta-based product designer and builder with more than
-              15 years shaping software people actually understand. Today I lead
-              product at Standard Education, turning K–12 analytics into tools
-              that help educators reach students before they fall behind.
+              I've spent fifteen years making things, and for most of that time
+              the making was the hard part. It isn't anymore. What's hard now,
+              and what I find myself caring about most, is knowing what's worth
+              making, getting it in front of real people fast, and being honest
+              about whether it actually helped.
             </p>
             <p>
-              Before that I designed growth and collaboration at FullStory,
-              research tooling at Glass, and product strategy at Signal Lantern.
-              I care about mission-driven work, systems that stay simple as they
-              scale, and interfaces that respect the person on the other side of
-              the screen.
+              Today I'm Head of Product at Standard Education, where we turn
+              K–12 analytics into tools that help educators reach students
+              before they fall behind. Before that I led design for product-led
+              growth and collaboration at{" "}
+              <a
+                href="https://fullstory.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--accent)] underline decoration-1 underline-offset-4 transition-colors hover:text-[var(--accent-strong)]"
+              >
+                FullStory
+              </a>
+              , rebuilt the survey-export experience at Glass for research teams
+              at brands like Unilever and Clorox, and shaped product strategy at{" "}
+              <a
+                href="https://signallantern.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--accent)] underline decoration-1 underline-offset-4 transition-colors hover:text-[var(--accent-strong)]"
+              >
+                Signal Lantern
+              </a>
+              .
+            </p>
+            <p>
+              The craft underneath still matters to me. Heuristic evaluation,
+              information architecture, design systems, the quiet scaffolding
+              that makes the next decision easier. It's what lets me move fast
+              on the right things instead of just fast. Good work doesn't erase
+              complexity so much as organize it, so the people I build for can
+              make confident choices, and so I can see whether the choice was
+              right.
+            </p>
+            <p className="text-xl italic text-[var(--ink-strong)]">
+              This site is a small experiment in that idea: a calm surface over
+              a lot of moving water.
             </p>
           </div>
 

--- a/src/app/articles/[slug]/loading.tsx
+++ b/src/app/articles/[slug]/loading.tsx
@@ -1,34 +1,23 @@
+import PageShell from "@/components/PageShell";
+
 export default function ArticleLoading() {
-    return (
-      <article className="max-w-3xl mx-auto py-8 px-4 animate-pulse">
-        <header className="mb-8">
-          {/* Feature image skeleton */}
-          <div className="mb-6 aspect-video relative rounded-lg overflow-hidden bg-gray-200 dark:bg-gray-700" />
-          
-          {/* Title skeleton */}
-          <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-4" />
-          
-          {/* Date skeleton */}
-          <div className="h-5 bg-gray-200 dark:bg-gray-700 rounded w-48 mb-2" />
-          
-          {/* Excerpt skeleton */}
-          <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-full" />
-        </header>
-        
-        {/* Content skeleton */}
-        <div className="prose prose-lg max-w-none dark:prose-invert">
-          <div className="space-y-4">
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-5/6" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-4/5" />
-            <div className="h-32 bg-gray-200 dark:bg-gray-700 rounded w-full my-6" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-5/6" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full" />
-          </div>
+  return (
+    <PageShell>
+      <article className="container mx-auto max-w-3xl animate-pulse px-4 py-14 md:py-20">
+        <div className="h-3 w-24 rounded bg-[var(--panel-2)]" />
+        <div className="mt-6 h-10 w-3/4 rounded bg-[var(--panel-2)]" />
+        <div className="mt-4 h-4 w-40 rounded bg-[var(--panel-2)]" />
+        <div className="mt-10 aspect-video w-full rounded-[4px] bg-[var(--panel-2)]" />
+        <div className="mt-12 space-y-4">
+          <div className="h-4 w-full rounded bg-[var(--panel-2)]" />
+          <div className="h-4 w-5/6 rounded bg-[var(--panel-2)]" />
+          <div className="h-4 w-full rounded bg-[var(--panel-2)]" />
+          <div className="h-4 w-4/5 rounded bg-[var(--panel-2)]" />
+          <div className="my-6 h-32 w-full rounded bg-[var(--panel-2)]" />
+          <div className="h-4 w-full rounded bg-[var(--panel-2)]" />
+          <div className="h-4 w-3/4 rounded bg-[var(--panel-2)]" />
         </div>
       </article>
-    );
-  }
+    </PageShell>
+  );
+}

--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import Image from "next/image";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import PageShell from "@/components/PageShell";
+import WaveRule from "@/components/WaveRule";
 import { getArticle, listArticles } from "../../../../lib/data/content";
 import Markdown from "../../../components/Markdown";
 
@@ -41,11 +44,37 @@ export default async function Page({ params }: Params) {
     notFound();
   }
 
+  const formattedDate = article.publishDate
+    ? new Date(article.publishDate).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : null;
+
   return (
-    <article className="max-w-3xl mx-auto py-8 px-4">
-      <header className="mb-8">
+    <PageShell>
+      <article className="container mx-auto max-w-3xl px-4 py-14 md:py-20">
+        <div className="tide-rise">
+          <Link
+            href="/articles"
+            className="eyebrow inline-flex items-center gap-2 transition-opacity hover:opacity-70"
+          >
+            <span aria-hidden="true">←</span> Articles
+          </Link>
+          <h1 className="page-title mt-6 text-3xl md:text-4xl lg:text-5xl">
+            {article.title}
+          </h1>
+          {formattedDate && (
+            <p className="mt-4 font-mono text-sm uppercase tracking-wider text-[var(--ink-muted)]">
+              {formattedDate}
+            </p>
+          )}
+          <WaveRule className="mt-8 max-w-[11rem] opacity-80" />
+        </div>
+
         {article.heroImage && (
-          <div className="mb-6 aspect-video relative rounded-lg overflow-hidden">
+          <div className="tide-rise tide-rise-1 relative mt-10 aspect-video overflow-hidden rounded-[4px] border border-[var(--panel-border)]">
             <Image
               src={article.heroImage}
               alt={article.title}
@@ -56,23 +85,11 @@ export default async function Page({ params }: Params) {
             />
           </div>
         )}
-        <h1 className="text-3xl md:text-4xl font-bold mb-4 text-gray-900 dark:text-gray-100">
-          {article.title}
-        </h1>
-        {article.publishDate && (
-          <p className="text-gray-600 dark:text-gray-400 mb-2">
-            {new Date(article.publishDate).toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            })}
-          </p>
-        )}
-      </header>
 
-      <div className="prose prose-lg max-w-none dark:prose-invert">
-        <Markdown source={article.content} />
-      </div>
-    </article>
+        <div className="ink-prose tide-rise tide-rise-2 mt-12">
+          <Markdown source={article.content} />
+        </div>
+      </article>
+    </PageShell>
   );
 }

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,6 +1,9 @@
 import Image from "next/image";
 import Link from "next/link";
 
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
+import WaveRule from "@/components/WaveRule";
 import { type Article, listArticles } from "../../../lib/data/content";
 
 export const metadata = {
@@ -14,21 +17,27 @@ export default async function ArticlesPage() {
   const articles = await listArticles();
 
   return (
-    <main className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8 text-gray-900 dark:text-gray-100">
-        Articles
-      </h1>
+    <PageShell>
+      <main className="container mx-auto px-4 py-14 md:py-20">
+        <PageHeader
+          eyebrow="Writing"
+          title="Articles"
+          subtitle="Notes on design, development, and the craft of making software."
+        />
 
-      {articles.length === 0 ? (
-        <p>No articles found. Check back soon!</p>
-      ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {articles.map((article) => (
-            <ArticleCard key={article.slug} article={article} />
-          ))}
-        </div>
-      )}
-    </main>
+        {articles.length === 0 ? (
+          <p className="lede mt-14 text-lg">
+            No articles yet — check back soon.
+          </p>
+        ) : (
+          <div className="tide-rise tide-rise-1 mt-12 grid grid-cols-1 gap-7 md:grid-cols-2 lg:grid-cols-3">
+            {articles.map((article) => (
+              <ArticleCard key={article.slug} article={article} />
+            ))}
+          </div>
+        )}
+      </main>
+    </PageShell>
   );
 }
 
@@ -41,40 +50,43 @@ function ArticleCard({ article }: { article: Article }) {
   });
 
   return (
-    <Link href={`/articles/${slug}`} className="block h-full" prefetch>
-      <div className="border rounded-lg overflow-hidden h-full flex flex-col hover:shadow-lg transition-shadow duration-300">
-        {heroImage ? (
-          <div className="h-48 relative overflow-hidden">
-            <Image
-              src={heroImage}
-              alt={title}
-              fill
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-              className="object-cover transition-transform hover:scale-105 duration-300"
-            />
-          </div>
-        ) : (
-          <div className="h-48 bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
-            <span className="text-gray-400 dark:text-gray-500">No image</span>
-          </div>
-        )}
-        <div className="p-4 flex-1 flex flex-col">
-          <h2 className="text-xl  font-semibold mb-2">{title}</h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-            {formattedDate}
-          </p>
-          {excerpt && (
-            <p className="mb-4 text-gray-700 dark:text-gray-300 flex-1">
-              {excerpt}
-            </p>
-          )}
-
-          <div className="mt-auto pt-4">
-            <span className="text-sm font-medium text-blue-600 dark:text-blue-400">
-              Read more →
-            </span>
-          </div>
+    <Link href={`/articles/${slug}`} className="tide-card group" prefetch>
+      {heroImage ? (
+        <div className="relative h-48 overflow-hidden">
+          <Image
+            src={heroImage}
+            alt={title}
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
+          />
         </div>
+      ) : (
+        <div className="flex h-48 items-center justify-center bg-[var(--panel-2)]">
+          <WaveRule className="w-2/3 opacity-70" />
+        </div>
+      )}
+      <div className="flex flex-1 flex-col p-5">
+        <p className="font-mono text-[0.68rem] uppercase tracking-wider text-[var(--ink-muted)]">
+          {formattedDate}
+        </p>
+        <h2 className="font-heading mt-2 text-xl leading-snug text-[var(--ink-strong)]">
+          {title}
+        </h2>
+        {excerpt && (
+          <p className="mt-2 flex-1 leading-relaxed text-[var(--ink-muted)]">
+            {excerpt}
+          </p>
+        )}
+        <span className="mt-5 inline-flex items-center gap-1.5 text-sm font-medium text-[var(--accent)]">
+          Read
+          <span
+            aria-hidden="true"
+            className="transition-transform duration-300 group-hover:translate-x-1"
+          >
+            →
+          </span>
+        </span>
       </div>
     </Link>
   );

--- a/src/app/case-studies/[slug]/page.tsx
+++ b/src/app/case-studies/[slug]/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import Image from "next/image";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import PageShell from "@/components/PageShell";
+import WaveRule from "@/components/WaveRule";
 import { getCaseStudy, listCaseStudies } from "../../../../lib/data/content";
 import Markdown from "../../../components/Markdown";
 
@@ -42,80 +45,78 @@ export default async function Page({ params }: Params) {
     notFound();
   }
 
+  const meta = [
+    { label: "Role", value: caseStudy.role },
+    { label: "Scope", value: caseStudy.scope },
+    { label: "Industry", value: caseStudy.industry },
+  ].filter((item) => item.value);
+
   return (
-    <article className="mx-auto max-w-4xl px-4 py-10">
-      <header className="mb-10">
+    <PageShell>
+      <article className="container mx-auto max-w-4xl px-4 py-14 md:py-20">
+        <header className="tide-rise">
+          <Link
+            href="/case-studies"
+            className="eyebrow inline-flex items-center gap-2 transition-opacity hover:opacity-70"
+          >
+            <span aria-hidden="true">←</span> Case Studies
+          </Link>
+          {caseStudy.client && (
+            <p className="mt-6 font-mono text-sm uppercase tracking-wider text-[var(--ink-muted)]">
+              {caseStudy.client}
+            </p>
+          )}
+          <h1 className="page-title mt-3 text-4xl leading-tight md:text-5xl">
+            {caseStudy.title}
+          </h1>
+          <WaveRule className="mt-8 max-w-[11rem] opacity-80" />
+
+          {meta.length > 0 && (
+            <dl className="mt-8 grid gap-5 border-y border-[var(--hairline)] py-6 text-sm sm:grid-cols-3">
+              {meta.map((item) => (
+                <div key={item.label}>
+                  <dt className="font-mono text-xs uppercase tracking-wider text-[var(--accent)]">
+                    {item.label}
+                  </dt>
+                  <dd className="mt-1.5 text-[var(--ink-strong)]">
+                    {item.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )}
+
+          {caseStudy.outcomes.length > 0 && (
+            <ul className="mt-6 grid gap-3 md:grid-cols-2">
+              {caseStudy.outcomes.map((outcome) => (
+                <li
+                  key={outcome}
+                  className="tide-panel p-4 text-sm leading-relaxed text-[var(--ink)]"
+                >
+                  {outcome}
+                </li>
+              ))}
+            </ul>
+          )}
+        </header>
+
         {caseStudy.heroImage && (
-          <div className="relative mb-8 aspect-video overflow-hidden rounded-lg">
+          <div className="tide-rise tide-rise-1 relative mt-10 aspect-video overflow-hidden rounded-[4px] border border-[var(--panel-border)]">
             <Image
               src={caseStudy.heroImage}
               alt={caseStudy.title}
               fill
               priority
-              sizes="(max-width: 768px) 100vw, 768px"
+              sizes="(max-width: 768px) 100vw, 896px"
               className="object-cover"
             />
           </div>
         )}
-        {caseStudy.client && (
-          <p className="mb-3 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
-            {caseStudy.client}
-          </p>
-        )}
-        <h1 className="mb-5 text-4xl font-bold leading-tight text-gray-900 dark:text-gray-100 md:text-5xl">
-          {caseStudy.title}
-        </h1>
 
-        <dl className="grid gap-4 border-y border-gray-200 py-5 text-sm dark:border-gray-800 sm:grid-cols-3">
-          {caseStudy.role && (
-            <div>
-              <dt className="font-semibold uppercase text-gray-500 dark:text-gray-400">
-                Role
-              </dt>
-              <dd className="mt-1 text-gray-900 dark:text-gray-100">
-                {caseStudy.role}
-              </dd>
-            </div>
-          )}
-          {caseStudy.scope && (
-            <div>
-              <dt className="font-semibold uppercase text-gray-500 dark:text-gray-400">
-                Scope
-              </dt>
-              <dd className="mt-1 text-gray-900 dark:text-gray-100">
-                {caseStudy.scope}
-              </dd>
-            </div>
-          )}
-          {caseStudy.industry && (
-            <div>
-              <dt className="font-semibold uppercase text-gray-500 dark:text-gray-400">
-                Industry
-              </dt>
-              <dd className="mt-1 text-gray-900 dark:text-gray-100">
-                {caseStudy.industry}
-              </dd>
-            </div>
-          )}
-        </dl>
-
-        {caseStudy.outcomes.length > 0 && (
-          <ul className="mt-6 grid gap-3 text-gray-700 dark:text-gray-300 md:grid-cols-2">
-            {caseStudy.outcomes.map((outcome) => (
-              <li
-                key={outcome}
-                className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-800 dark:bg-gray-900"
-              >
-                {outcome}
-              </li>
-            ))}
-          </ul>
-        )}
-      </header>
-
-      <div className="prose prose-lg max-w-none dark:prose-invert">
-        <Markdown source={caseStudy.content} />
-      </div>
-    </article>
+        <div className="ink-prose tide-rise tide-rise-2 mt-12">
+          <Markdown source={caseStudy.content} />
+        </div>
+      </article>
+    </PageShell>
   );
 }

--- a/src/app/case-studies/page.tsx
+++ b/src/app/case-studies/page.tsx
@@ -1,6 +1,9 @@
 import Image from "next/image";
 import Link from "next/link";
 
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
+import WaveRule from "@/components/WaveRule";
 import { type CaseStudy, listCaseStudies } from "../../../lib/data/content";
 
 export const metadata = {
@@ -14,27 +17,27 @@ export default async function CaseStudiesPage() {
   const caseStudies = await listCaseStudies();
 
   return (
-    <section className="container mx-auto px-4 py-10">
-      <div className="mb-10 max-w-3xl">
-        <h1 className="mb-3 text-4xl font-bold text-gray-900 dark:text-gray-100">
-          Case Studies
-        </h1>
-        <p className="text-lg leading-relaxed text-gray-600 dark:text-gray-300">
-          Product strategy, UX systems, and interface design work for teams
-          building complex software.
-        </p>
-      </div>
+    <PageShell>
+      <section className="container mx-auto px-4 py-14 md:py-20">
+        <PageHeader
+          eyebrow="Selected Work"
+          title="Case Studies"
+          subtitle="Product strategy, UX systems, and interface design for teams building complex software."
+        />
 
-      {caseStudies.length === 0 ? (
-        <p>No case studies found. Check back soon!</p>
-      ) : (
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
-          {caseStudies.map((caseStudy) => (
-            <CaseStudyCard key={caseStudy.slug} caseStudy={caseStudy} />
-          ))}
-        </div>
-      )}
-    </section>
+        {caseStudies.length === 0 ? (
+          <p className="lede mt-14 text-lg">
+            No case studies yet — check back soon.
+          </p>
+        ) : (
+          <div className="tide-rise tide-rise-1 mt-12 grid grid-cols-1 gap-7 md:grid-cols-2 xl:grid-cols-3">
+            {caseStudies.map((caseStudy) => (
+              <CaseStudyCard key={caseStudy.slug} caseStudy={caseStudy} />
+            ))}
+          </div>
+        )}
+      </section>
+    </PageShell>
   );
 }
 
@@ -54,59 +57,62 @@ function CaseStudyCard({ caseStudy }: { caseStudy: CaseStudy }) {
     month: "long",
     day: "numeric",
   });
+  const eyebrow = [client, role].filter(Boolean).join(" / ") || formattedDate;
 
   return (
-    <Link href={`/case-studies/${slug}`} className="block h-full" prefetch>
-      <article className="flex h-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white transition-shadow duration-300 hover:shadow-lg dark:border-gray-800 dark:bg-gray-950">
-        {heroImage ? (
-          <div className="relative h-48 overflow-hidden">
-            <Image
-              src={heroImage}
-              alt={title}
-              fill
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-              className="object-cover transition-transform hover:scale-105 duration-300"
-            />
-          </div>
-        ) : (
-          <div className="flex h-48 items-center justify-center bg-gray-100 dark:bg-gray-900">
-            <span className="text-sm font-medium uppercase text-gray-400 dark:text-gray-500">
-              {client || "Case study"}
-            </span>
-          </div>
-        )}
-        <div className="flex flex-1 flex-col p-5">
-          <p className="mb-2 text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
-            {[client, role].filter(Boolean).join(" / ") || formattedDate}
-          </p>
-          <h2 className="mb-3 text-2xl font-semibold leading-tight text-gray-950 dark:text-white">
-            {title}
-          </h2>
-          {excerpt && (
-            <p className="mb-4 flex-1 leading-relaxed text-gray-700 dark:text-gray-300">
-              {excerpt}
-            </p>
-          )}
-          {outcomes.length > 0 && (
-            <ul className="mb-4 space-y-2 text-sm text-gray-600 dark:text-gray-300">
-              {outcomes.slice(0, 2).map((outcome) => (
-                <li
-                  key={outcome}
-                  className="border-l border-gray-300 pl-3 dark:border-gray-700"
-                >
-                  {outcome}
-                </li>
-              ))}
-            </ul>
-          )}
-
-          <div className="mt-auto pt-2">
-            <span className="text-sm font-medium text-blue-600 dark:text-blue-400">
-              Read more →
-            </span>
-          </div>
+    <Link href={`/case-studies/${slug}`} className="tide-card group" prefetch>
+      {heroImage ? (
+        <div className="relative h-48 overflow-hidden">
+          <Image
+            src={heroImage}
+            alt={title}
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
+          />
         </div>
-      </article>
+      ) : (
+        <div className="flex h-48 flex-col items-center justify-center gap-3 bg-[var(--panel-2)]">
+          <span className="font-mono text-xs uppercase tracking-wider text-[var(--ink-muted)]">
+            {client || "Case study"}
+          </span>
+          <WaveRule className="w-1/2 opacity-70" />
+        </div>
+      )}
+      <div className="flex flex-1 flex-col p-5">
+        <p className="font-mono text-[0.68rem] uppercase tracking-wider text-[var(--accent)]">
+          {eyebrow}
+        </p>
+        <h2 className="font-heading mt-2 text-2xl leading-tight text-[var(--ink-strong)]">
+          {title}
+        </h2>
+        {excerpt && (
+          <p className="mt-2 flex-1 leading-relaxed text-[var(--ink-muted)]">
+            {excerpt}
+          </p>
+        )}
+        {outcomes.length > 0 && (
+          <ul className="mt-4 space-y-2 text-sm text-[var(--ink)]">
+            {outcomes.slice(0, 2).map((outcome) => (
+              <li
+                key={outcome}
+                className="border-l border-[var(--panel-border-strong)] pl-3"
+              >
+                {outcome}
+              </li>
+            ))}
+          </ul>
+        )}
+        <span className="mt-5 inline-flex items-center gap-1.5 text-sm font-medium text-[var(--accent)]">
+          Read case study
+          <span
+            aria-hidden="true"
+            className="transition-transform duration-300 group-hover:translate-x-1"
+          >
+            →
+          </span>
+        </span>
+      </div>
     </Link>
   );
 }

--- a/src/app/components/AboutBlurb.tsx
+++ b/src/app/components/AboutBlurb.tsx
@@ -3,24 +3,22 @@ export const revalidate = 3600; // 1 hour (matches cron frequency)
 import { kv } from "#lib/kv";
 
 export default async function AboutBlurb() {
-  try {
-    const blurb = await kv.get<string>("blurb");
+  let blurb: string | null = null;
 
-    return (
-      <div className="about-blurb my-6">
-        <p className="prose max-w-xl text-xl italic leading-relaxed text-gray-900 dark:text-gray-100">
-          {blurb ?? "Loading..."}
-        </p>
-      </div>
-    );
+  try {
+    blurb = await kv.get<string>("blurb");
   } catch (error) {
     console.error("Failed to fetch blurb from KV:", error);
-    return (
-      <div className="about-blurb my-6">
-        <p className="prose max-w-xl text-xl italic leading-relaxed text-gray-900 dark:text-gray-100">
-          Loading...
-        </p>
-      </div>
-    );
   }
+
+  return (
+    <figure className="about-blurb border-l-2 border-[var(--accent)] pl-5">
+      <p className="text-xl italic leading-relaxed text-[var(--ink-strong)] md:text-2xl">
+        {blurb ?? "Loading..."}
+      </p>
+      <figcaption className="mt-3 font-mono text-[0.68rem] uppercase tracking-wider text-[var(--ink-muted)]">
+        Today, in brief
+      </figcaption>
+    </figure>
+  );
 }

--- a/src/app/components/FeedlyArticlesWidget.tsx
+++ b/src/app/components/FeedlyArticlesWidget.tsx
@@ -1,9 +1,9 @@
 export const revalidate = 86_400; // 24 hours (daily refresh)
 
-import type { Profile } from "#lib/profile";
-import { kv } from "#lib/kv";
-import type { FeedlyArticle, FeedlyData } from "#lib/providers/feedly";
 import { formatUpdatedAt } from "@/lib/date";
+import { kv } from "#lib/kv";
+import type { Profile } from "#lib/profile";
+import type { FeedlyArticle, FeedlyData } from "#lib/providers/feedly";
 
 type FeedlyProfile = Pick<Profile, "feedly">;
 
@@ -25,18 +25,22 @@ export default async function FeedlyArticlesWidget() {
 
   if (latestArticles.length === 0) {
     return (
-      <div className="feedly-widget rounded-lg border border-gray-200 bg-gray-100 p-4 text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+      <div className="feedly-widget tide-panel p-5 text-[var(--ink-muted)]">
         No articles available
       </div>
     );
   }
 
   return (
-    <div className="feedly-widget mb-4">
-      <div className="mb-3 flex flex-col gap-1 text-gray-500 dark:text-gray-400 sm:flex-row sm:items-center sm:justify-between">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Latest Reads</h3>
+    <div className="feedly-widget">
+      <div className="mb-3 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <h3 className="text-lg font-semibold text-[var(--ink-strong)]">
+          Latest Reads
+        </h3>
         {feedlyData?.lastUpdated && (
-          <span className="text-xs">Updated {formatUpdatedAt(feedlyData.lastUpdated)}</span>
+          <span className="font-mono text-[0.68rem] uppercase tracking-wider text-[var(--ink-muted)]">
+            Updated {formatUpdatedAt(feedlyData.lastUpdated)}
+          </span>
         )}
       </div>
 
@@ -47,30 +51,36 @@ export default async function FeedlyArticlesWidget() {
             href={article.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="article-card flex h-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white transition-all hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
+            className="article-card tide-card group"
           >
             {article.imageUrl ? (
               <div className="article-image h-40 overflow-hidden">
                 <img
                   src={article.imageUrl}
                   alt={article.title}
-                  className="h-full w-full object-cover"
+                  className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
                 />
               </div>
             ) : (
-              <div className="article-image-placeholder flex h-40 items-center justify-center bg-gray-200 dark:bg-gray-700">
-                <span className="text-gray-400 dark:text-gray-500">No image</span>
+              <div className="article-image-placeholder flex h-40 items-center justify-center bg-[var(--panel-2)]">
+                <span className="font-mono text-xs uppercase tracking-wider text-[var(--ink-muted)]">
+                  No image
+                </span>
               </div>
             )}
 
             <div className="article-content flex flex-1 flex-col p-4">
-              <h4 className="mb-2 line-clamp-2 text-base font-medium text-gray-900 dark:text-white">{article.title}</h4>
+              <h4 className="mb-2 line-clamp-2 text-base font-medium text-[var(--ink-strong)]">
+                {article.title}
+              </h4>
 
               {article.excerpt && (
-                <p className="mb-3 line-clamp-3 text-sm text-gray-600 dark:text-gray-300">{article.excerpt}</p>
+                <p className="mb-3 line-clamp-3 text-sm text-[var(--ink-muted)]">
+                  {article.excerpt}
+                </p>
               )}
 
-              <div className="article-meta mt-auto flex items-center justify-end text-xs text-gray-500 dark:text-gray-400">
+              <div className="article-meta mt-auto flex items-center justify-end font-mono text-[0.68rem] uppercase tracking-wider text-[var(--ink-muted)]">
                 {article.source && <span>{article.source}</span>}
               </div>
             </div>

--- a/src/app/components/SpotifyWidget.tsx
+++ b/src/app/components/SpotifyWidget.tsx
@@ -1,9 +1,9 @@
 export const revalidate = 3600; // 1 hour (matches cron frequency)
 
-import type { Profile } from "#lib/profile";
-import { kv } from "#lib/kv";
-import type { SpotifyTrack } from "#lib/providers/spotify";
 import { formatUpdatedAt } from "@/lib/date";
+import { kv } from "#lib/kv";
+import type { Profile } from "#lib/profile";
+import type { SpotifyTrack } from "#lib/providers/spotify";
 
 type SpotifyProfile = Pick<Profile, "spotify">;
 
@@ -21,10 +21,10 @@ export default async function SpotifyWidget() {
 
   if (!trackData) {
     return (
-      <div className="spotify-widget rounded-lg border border-gray-200 bg-gray-100 p-4 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+      <div className="spotify-widget tide-panel p-5 text-[var(--ink-muted)]">
         <p>Music data unavailable</p>
         {spotifyData?.lastUpdated && (
-          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          <p className="mt-2 font-mono text-[0.68rem] uppercase tracking-wider text-[var(--ink-muted)]">
             Updated {formatUpdatedAt(spotifyData.lastUpdated)}
           </p>
         )}
@@ -33,19 +33,25 @@ export default async function SpotifyWidget() {
   }
 
   return (
-    <div className="spotify-widget rounded-lg border border-gray-200 bg-gray-100 p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Recently Played</h3>
+    <div className="spotify-widget tide-panel p-5">
+      <h3 className="text-lg font-semibold text-[var(--ink-strong)]">
+        Recently Played
+      </h3>
       <div className="mt-2 flex items-center">
         <span className="mr-3 text-3xl">🎵</span>
         <div className="flex-1">
-          <p className="text-lg font-medium text-gray-900 dark:text-white">{trackData.title}</p>
-          <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">by {trackData.artist}</p>
+          <p className="text-lg font-medium text-[var(--ink-strong)]">
+            {trackData.title}
+          </p>
+          <p className="mt-1 text-sm text-[var(--ink-muted)]">
+            by {trackData.artist}
+          </p>
           {trackData.trackUrl && (
             <a
               href={trackData.trackUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="mt-2 inline-block text-xs text-green-600 transition-colors hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
+              className="mt-2 inline-block text-xs font-medium text-[var(--accent)] transition-colors hover:text-[var(--accent-strong)]"
             >
               Listen on Spotify →
             </a>
@@ -53,7 +59,7 @@ export default async function SpotifyWidget() {
         </div>
       </div>
       {spotifyData?.lastUpdated && (
-        <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">
+        <p className="mt-4 font-mono text-[0.68rem] uppercase tracking-wider text-[var(--ink-muted)]">
           Updated {formatUpdatedAt(spotifyData.lastUpdated)}
         </p>
       )}

--- a/src/app/components/WeatherWidget.tsx
+++ b/src/app/components/WeatherWidget.tsx
@@ -1,18 +1,26 @@
 export const revalidate = 3600; // 1 hour (matches cron frequency)
 
-import type { Profile } from "#lib/profile";
-import { kv } from "#lib/kv";
-import type { Weather } from "#lib/providers/weather";
 import { formatUpdatedAt } from "@/lib/date";
+import { kv } from "#lib/kv";
+import type { Profile } from "#lib/profile";
+import type { Weather } from "#lib/providers/weather";
 
 type WeatherProfile = Pick<Profile, "weather">;
 
 function getWeatherIcon(condition: string): string {
   const normalizedCondition = condition.toLowerCase();
 
-  if (normalizedCondition.includes("clear") || normalizedCondition.includes("sun")) return "☀️";
+  if (
+    normalizedCondition.includes("clear") ||
+    normalizedCondition.includes("sun")
+  )
+    return "☀️";
   if (normalizedCondition.includes("cloud")) return "☁️";
-  if (normalizedCondition.includes("rain") || normalizedCondition.includes("drizzle")) return "🌧️";
+  if (
+    normalizedCondition.includes("rain") ||
+    normalizedCondition.includes("drizzle")
+  )
+    return "🌧️";
   if (normalizedCondition.includes("snow")) return "❄️";
   if (normalizedCondition.includes("fog")) return "🌫️";
   if (normalizedCondition.includes("thunder")) return "⚡";
@@ -21,7 +29,9 @@ function getWeatherIcon(condition: string): string {
 }
 
 function formatTemperatureRange(weather: Weather): string {
-  return `${Math.round(weather.temperature_low)}° - ${Math.round(weather.temperature_high)}°F`;
+  return `${Math.round(weather.temperature_low)}° - ${Math.round(
+    weather.temperature_high,
+  )}°F`;
 }
 
 export default async function WeatherWidget() {
@@ -36,26 +46,32 @@ export default async function WeatherWidget() {
 
   if (!weatherData) {
     return (
-      <div className="weather-widget rounded-lg border border-gray-200 bg-gray-100 p-4 text-gray-900 shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+      <div className="weather-widget tide-panel p-5 text-[var(--ink-muted)]">
         Weather data unavailable
       </div>
     );
   }
 
   return (
-    <div className="weather-widget rounded-lg border border-gray-200 bg-gray-100 p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Weather in {weatherData.city}</h3>
+    <div className="weather-widget tide-panel p-5">
+      <h3 className="text-lg font-semibold text-[var(--ink-strong)]">
+        Weather in {weatherData.city}
+      </h3>
       <div className="mt-2 flex items-center">
-        <span className="mr-3 text-3xl">{getWeatherIcon(weatherData.condition)}</span>
+        <span className="mr-3 text-3xl">
+          {getWeatherIcon(weatherData.condition)}
+        </span>
         <div className="flex-1">
-          <p className="text-lg font-medium text-gray-900 dark:text-white">
+          <p className="text-lg font-medium text-[var(--ink-strong)]">
             {Math.round(weatherData.temperature)}°F • {weatherData.condition}
           </p>
-          <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">Today: {formatTemperatureRange(weatherData)}</p>
+          <p className="mt-1 text-sm text-[var(--ink-muted)]">
+            Today: {formatTemperatureRange(weatherData)}
+          </p>
         </div>
       </div>
 
-      <dl className="mt-3 space-y-1 text-sm text-gray-700 dark:text-gray-300">
+      <dl className="mt-3 space-y-1 text-sm text-[var(--ink)]">
         <div className="flex justify-between">
           <dt>Humidity:</dt>
           <dd className="font-medium">
@@ -68,7 +84,7 @@ export default async function WeatherWidget() {
         </div>
       </dl>
 
-      <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">
+      <p className="mt-4 font-mono text-[0.68rem] uppercase tracking-wider text-[var(--ink-muted)]">
         Updated {formatUpdatedAt(weatherData.lastUpdated)}
       </p>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,9 @@
 /* Import our comprehensive theme system */
 @import "../styles/theme.css";
 
+/* Inner-page seascape design system (articles, case studies, about) */
+@import "../styles/pages.css";
+
 /* Base dark/light mode variables */
 :root {
   --background: #ffffff;

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+import WaveRule from "@/components/WaveRule";
+
+type PageHeaderProps = {
+  eyebrow?: string;
+  title: ReactNode;
+  subtitle?: ReactNode;
+};
+
+/**
+ * PageHeader — the shared masthead for inner pages: a mono eyebrow, an Apoc
+ * display title, an optional lede, and a hairline wave rule. Animates in
+ * gently on load (disabled under prefers-reduced-motion).
+ */
+export default function PageHeader({
+  eyebrow,
+  title,
+  subtitle,
+}: PageHeaderProps) {
+  return (
+    <header className="tide-rise">
+      {eyebrow ? <p className="eyebrow mb-3">{eyebrow}</p> : null}
+      <h1 className="page-title text-4xl md:text-5xl lg:text-6xl">{title}</h1>
+      {subtitle ? (
+        <p className="lede mt-4 max-w-2xl text-lg md:text-xl">{subtitle}</p>
+      ) : null}
+      <WaveRule className="mt-8 max-w-[11rem] opacity-80" />
+    </header>
+  );
+}

--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+/**
+ * PageShell — wraps an inner page in the themed seascape ground.
+ *
+ * The homepage keeps its full animated canvas; every other page renders this
+ * calmer, readable ground instead. The background is a fixed, full-bleed layer
+ * so the paper/deep-sea color sits behind the floating nav with no seam.
+ */
+export default function PageShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="page-shell">
+      <div className="page-shell__bg" aria-hidden="true" />
+      {children}
+    </div>
+  );
+}

--- a/src/components/WaveRule.tsx
+++ b/src/components/WaveRule.tsx
@@ -1,0 +1,41 @@
+/**
+ * WaveRule — a seamless, theme-aware hairline of ukiyo-e foam crests.
+ *
+ * A quiet reuse of the homepage's wave language as a static divider. The
+ * stroke follows `currentColor` (set to `--wave-stroke` via the `.wave-rule`
+ * class), so it adapts to the active Hokusai / Twilight theme. The path is a
+ * single 120px period that returns to its baseline, so it tiles cleanly.
+ */
+export default function WaveRule({ className }: { className?: string }) {
+  const classes = className ? `wave-rule ${className}` : "wave-rule";
+
+  return (
+    <svg
+      className={classes}
+      width="100%"
+      height="16"
+      fill="none"
+      role="presentation"
+      aria-hidden="true"
+    >
+      <title>Decorative wave</title>
+      <defs>
+        <pattern
+          id="wave-rule-foam"
+          width="120"
+          height="16"
+          patternUnits="userSpaceOnUse"
+        >
+          <path
+            d="M0 8 C 12 8 18 4 30 4 S 48 4 60 8 S 78 12 90 12 S 108 12 120 8"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+            fill="none"
+          />
+        </pattern>
+      </defs>
+      <rect width="100%" height="16" fill="url(#wave-rule-foam)" />
+    </svg>
+  );
+}

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -1,0 +1,288 @@
+/*
+ * Seascape inner-page design system — "Shoreline"
+ * --------------------------------------------------------------------------
+ * Carries the homepage ukiyo-e aesthetic (Hokusai indigo + cream/amber foam)
+ * across the articles, case-study, and about pages with a calm, editorial,
+ * readability-first treatment. No animated art scenes — just the palette,
+ * the display type, hairline wave motifs, and gentle on-load motion.
+ */
+
+/* =========================================================================
+ * Theme-aware tokens
+ * Light ("hokusai")  -> warm paper + deep indigo ink + bronze-amber accent
+ * Dark  ("twilight") -> deep-sea ground + cream-foam ink + warm-amber accent
+ * ========================================================================= */
+:root[data-theme="hokusai"] {
+  --page-bg: #faf7ef;
+  --page-bg-top: #eef1f7;
+  --ink-strong: #12203a;
+  --ink: #2a3447;
+  --ink-muted: #5b6577;
+  --panel: #ffffff;
+  --panel-2: #f4f1e8;
+  --panel-border: rgba(18, 32, 58, 0.12);
+  --panel-border-strong: rgba(18, 32, 58, 0.26);
+  --hairline: rgba(18, 32, 58, 0.12);
+  --accent: #a85f1a;
+  --accent-strong: #864a12;
+  --wave-stroke: rgba(18, 32, 58, 0.32);
+  --card-shadow: rgba(18, 32, 58, 0.5);
+}
+
+:root[data-theme="twilight"],
+:root.dark {
+  --page-bg: #0a0f1a;
+  --page-bg-top: #0d1526;
+  --ink-strong: #ede2ca;
+  --ink: #c6ccd9;
+  --ink-muted: #8a93a7;
+  --panel: rgba(255, 255, 255, 0.04);
+  --panel-2: rgba(255, 255, 255, 0.06);
+  --panel-border: rgba(208, 152, 92, 0.2);
+  --panel-border-strong: rgba(208, 152, 92, 0.4);
+  --hairline: rgba(237, 226, 202, 0.12);
+  --accent: #e0a565;
+  --accent-strong: #f0c99c;
+  --wave-stroke: rgba(208, 152, 92, 0.4);
+  --card-shadow: rgba(0, 0, 0, 0.7);
+}
+
+/* =========================================================================
+ * Page shell — a full-bleed themed ground behind inner pages only
+ * (the homepage keeps its animated canvas; it never renders this shell).
+ * ========================================================================= */
+.page-shell {
+  position: relative;
+  min-height: 100vh;
+  color: var(--ink);
+}
+
+.page-shell__bg {
+  position: fixed;
+  inset: 0;
+  z-index: -10;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    var(--page-bg-top) 0%,
+    var(--page-bg) 36%,
+    var(--page-bg) 100%
+  );
+}
+
+/* =========================================================================
+ * Typographic primitives
+ * ========================================================================= */
+.eyebrow {
+  font-family: var(--font-geist-mono), monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--accent);
+}
+
+.page-title {
+  font-family: var(--font-apoc), serif;
+  color: var(--ink-strong);
+  line-height: 1.04;
+  letter-spacing: -0.01em;
+}
+
+.lede {
+  color: var(--ink-muted);
+  font-family: var(--font-instrument), serif;
+  line-height: 1.5;
+}
+
+/* =========================================================================
+ * Wave hairline divider (seamless, theme-aware, decorative)
+ * ========================================================================= */
+.wave-rule {
+  display: block;
+  width: 100%;
+  height: 16px;
+  color: var(--wave-stroke);
+}
+
+/* =========================================================================
+ * Cards & panels
+ * ========================================================================= */
+.tide-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 4px;
+  overflow: hidden;
+  transition:
+    transform 0.35s cubic-bezier(0, 0, 0.2, 1),
+    border-color 0.35s ease,
+    box-shadow 0.35s ease;
+}
+
+.tide-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--panel-border-strong);
+  box-shadow: 0 18px 42px -26px var(--card-shadow);
+}
+
+.tide-panel {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+}
+
+/* =========================================================================
+ * Long-form content — replaces the (unconfigured) Tailwind `prose` classes
+ * with a themed reading experience tuned to the seascape palette.
+ * ========================================================================= */
+.ink-prose {
+  color: var(--ink);
+  font-family: var(--font-instrument), serif;
+  font-size: 1.1rem;
+  line-height: 1.78;
+}
+
+.ink-prose > * + * {
+  margin-top: 1.3em;
+}
+
+.ink-prose h2 {
+  font-family: var(--font-apoc), serif;
+  color: var(--ink-strong);
+  font-size: clamp(1.5rem, 1.2rem + 1.1vw, 1.9rem);
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  margin-top: 2.4em;
+}
+
+.ink-prose h3 {
+  font-family: var(--font-instrument), serif;
+  color: var(--ink-strong);
+  font-weight: 600;
+  font-size: 1.28rem;
+  margin-top: 1.9em;
+}
+
+.ink-prose h2 + *,
+.ink-prose h3 + * {
+  margin-top: 0.8em;
+}
+
+.ink-prose a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  transition: color 0.2s ease;
+}
+
+.ink-prose a:hover {
+  color: var(--accent-strong);
+}
+
+.ink-prose strong {
+  color: var(--ink-strong);
+  font-weight: 600;
+}
+
+.ink-prose em {
+  font-style: italic;
+}
+
+.ink-prose ul,
+.ink-prose ol {
+  padding-left: 1.4em;
+}
+
+.ink-prose li {
+  margin-top: 0.5em;
+}
+
+.ink-prose ul > li::marker {
+  color: var(--accent);
+}
+
+.ink-prose ol > li::marker {
+  color: var(--ink-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.ink-prose blockquote {
+  margin-left: 0;
+  padding: 0.2em 0 0.2em 1.4rem;
+  border-left: 2px solid var(--accent);
+  color: var(--ink-strong);
+  font-style: italic;
+  font-size: 1.2rem;
+  line-height: 1.6;
+}
+
+.ink-prose blockquote p {
+  margin: 0;
+}
+
+.ink-prose code {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.9em;
+  background: var(--panel-2);
+  border: 1px solid var(--hairline);
+  padding: 0.12em 0.4em;
+  border-radius: 3px;
+  color: var(--ink-strong);
+}
+
+.ink-prose pre {
+  background: var(--panel-2);
+  border: 1px solid var(--hairline);
+  border-radius: 6px;
+  padding: 1rem 1.1rem;
+  overflow-x: auto;
+}
+
+.ink-prose pre code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+/* =========================================================================
+ * Gentle on-load motion (respects reduced-motion)
+ * ========================================================================= */
+@keyframes tide-rise {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.tide-rise {
+  animation: tide-rise 0.7s cubic-bezier(0, 0, 0.2, 1) both;
+}
+
+.tide-rise-1 {
+  animation-delay: 0.07s;
+}
+
+.tide-rise-2 {
+  animation-delay: 0.14s;
+}
+
+.tide-rise-3 {
+  animation-delay: 0.21s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tide-rise,
+  .tide-rise-1,
+  .tide-rise-2,
+  .tide-rise-3 {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Variation A — “Shoreline”

One of **two** independent explorations that extend the homepage ukiyo‑e aesthetic to the rest of the site. This is the **refined / production‑ready** direction. (The bold counterpart is Variation B — “Undertow” — on a separate branch/PR. The two are not meant to be merged together; pick one.)

### Design direction
Calm and editorial. It carries the homepage’s visual language — Hokusai indigo + cream/amber foam, the Apoc display face, a wave motif — onto the inner pages, but **dials the intensity way down** so long‑form reading stays comfortable. No new art scenes: just palette, type, a hairline wave rule, and a gentle on‑load rise. Readability‑first in both the Hokusai (light) and Twilight (dark) themes.

### What changed
- **New inner‑page design system** (`src/styles/pages.css`): theme‑aware tokens (warm‑paper / deep‑sea grounds, indigo / cream ink, bronze / amber accent), a full‑bleed `PageShell` ground, refined `tide-card` / `tide-panel` surfaces, and an `ink-prose` long‑form style set.
  - Note: the article/case‑study bodies previously used Tailwind `prose` classes, but the typography plugin was never installed — so they rendered essentially unstyled. `ink-prose` gives them a real, themed typographic hierarchy with **no new dependency**.
- **New components:** `PageShell`, `PageHeader` (mono eyebrow + Apoc title + wave rule), and `WaveRule` (a seamless, theme‑aware foam hairline reused from the homepage’s wave language).
- **Articles & Case Studies** — restyled card grids and themed reading pages (back‑link, display title, wave rule, case‑study meta + outcomes, themed body).
- **About** — a short, punchy bio, an “elsewhere” links row (GitHub / email / Signal Lantern), and a restyled **Daily Profile** section.
- **Widgets** (Weather, Spotify, Feedly, AboutBlurb) reskinned to the palette. **Their Vercel KV / API data flow is untouched** — only container and text classes changed.

### Verification
- `pnpm build` ✅ (12/12 static pages; Keystatic + all API routes intact)
- `pnpm test` ✅ (13/13)
- Biome ✅ on all changed files
- The Keystatic CMS (`/keystatic`) and the About‑page widgets read from the same env/KV as before — no functional changes.

### Fonts note
You mentioned a purchased font pack in Dropbox — that isn’t reachable from this isolated cloud container, so Variation A stays on the existing Apoc + Instrument Sans + Geist Mono trio. (Variation B experiments with an additional display face.)

https://claude.ai/code/session_01HduwL9h8aU8ZMaopdHtt6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HduwL9h8aU8ZMaopdHtt6z)_