### PR TITLE
Refactor about page: remove principles section, add disclosure widget

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,6 +2,7 @@ import AboutBlurb from "@/app/components/AboutBlurb";
 import FeedlyArticlesWidget from "@/app/components/FeedlyArticlesWidget";
 import SpotifyWidget from "@/app/components/SpotifyWidget";
 import WeatherWidget from "@/app/components/WeatherWidget";
+import Disclosure from "@/components/Disclosure";
 import DriftingWave from "@/components/DriftingWave";
 import PageShell from "@/components/PageShell";
 
@@ -15,21 +16,6 @@ export const metadata = {
 // page. Revalidate hourly so they stay fresh even between cron runs; the cron
 // job also calls revalidatePath('/about') right after each profile update.
 export const revalidate = 3600;
-
-const principles = [
-  {
-    title: "Mission first",
-    body: "Designing for educators and students keeps the work grounded and consequential.",
-  },
-  {
-    title: "Simple scales",
-    body: "Clear systems outlast clever ones — especially as a product moves from service to software.",
-  },
-  {
-    title: "Respect attention",
-    body: "Organize complexity instead of hiding it, so people can choose with confidence.",
-  },
-];
 
 const elsewhere = [
   { label: "GitHub", href: "https://github.com/jrelgin" },
@@ -49,25 +35,31 @@ export default function AboutPage() {
               Jason Elgin
             </h1>
             <p className="u-lede mt-5 text-2xl">
-              Head of Product at Standard Education, after fifteen years of
-              turning messy problems into software that works.
+              Head of Product at Standard Education. Over 15 years of turning
+              messy problems into software that works.
             </p>
             <DriftingWave className="mt-8 max-w-[16rem]" />
           </div>
 
           <div className="u-rise u-rise-1 mt-10 max-w-2xl space-y-6 text-lg leading-relaxed text-[var(--u-ink)]">
             <p>
-              I've spent fifteen years making things, and for most of that time
-              the making was the hard part. It isn't anymore. What's hard now,
-              and what I find myself caring about most, is knowing what's worth
-              making, getting it in front of real people fast, and being honest
-              about whether it actually helped.
+              For most of that time, the making was the hard part. It isn't
+              anymore. What's hard now, and what I find myself caring about
+              most, is knowing what's worth making, getting it in front of real
+              people fast, and being honest about whether it actually helped.
             </p>
             <p>
-              Today I'm Head of Product at Standard Education, where we turn
-              K–12 analytics into tools that help educators reach students
-              before they fall behind. Before that I led design for product-led
-              growth and collaboration at{" "}
+              The craft underneath still matters to me: heuristic evaluation,
+              information architecture, design systems, the quiet scaffolding
+              that makes the next decision easier. Good work doesn't erase
+              complexity so much as organize it, so the people I build for can
+              make confident choices.
+            </p>
+            <p>
+              That's the work at Standard Education, where we turn K-12
+              analytics into tools that help educators reach students before
+              they fall behind. Before that, I led design for product-led growth
+              and collaboration at{" "}
               <a
                 href="https://fullstory.com"
                 target="_blank"
@@ -88,31 +80,12 @@ export default function AboutPage() {
               </a>
               .
             </p>
-            <p>
-              The craft underneath still matters to me. Heuristic evaluation,
-              information architecture, design systems, the quiet scaffolding
-              that makes the next decision easier. It's what lets me move fast
-              on the right things instead of just fast. Good work doesn't erase
-              complexity so much as organize it, so the people I build for can
-              make confident choices, and so I can see whether the choice was
-              right.
-            </p>
             <p className="font-[family-name:var(--font-instrument-serif)] text-xl italic text-[var(--u-ink-strong)]">
               This site is a small experiment in that idea: a calm surface over
-              a lot of moving water.
+              a lot of moving water. Below is some of that water, the parts of
+              my days that move on their own.
             </p>
           </div>
-
-          <ul className="u-rise u-rise-1 mt-12 grid max-w-3xl gap-4 sm:grid-cols-3">
-            {principles.map((principle) => (
-              <li key={principle.title} className="frost-panel p-5">
-                <p className="u-eyebrow text-base">{principle.title}</p>
-                <p className="mt-2 text-sm leading-relaxed text-[var(--u-ink-muted)]">
-                  {principle.body}
-                </p>
-              </li>
-            ))}
-          </ul>
 
           <ul className="u-rise u-rise-2 mt-10 flex flex-wrap gap-x-6 gap-y-2 font-mono text-xs uppercase tracking-wider">
             {elsewhere.map((item) => (
@@ -128,28 +101,36 @@ export default function AboutPage() {
               </li>
             ))}
           </ul>
-
-          <div className="u-rise u-rise-2 mt-12">
-            <AboutBlurb />
-          </div>
         </div>
       </section>
 
       <section className="container mx-auto max-w-4xl px-4 pb-16">
         <div className="read-veil">
-          <p className="u-eyebrow text-lg">Right now</p>
-          <h2 className="u-title mt-2 text-4xl md:text-5xl">Daily Profile</h2>
-          <p className="u-lede mt-3 max-w-xl text-lg">
-            A small, automatically-updating snapshot — the weather over Atlanta,
-            what I've been listening to, and what I've been reading.
-          </p>
+          <h2 className="u-title text-4xl md:text-5xl">Right now</h2>
 
-          <div className="mt-8 grid gap-6 md:grid-cols-2">
+          <Disclosure
+            className="u-rise u-rise-1 mt-4"
+            label="Wait, what is this?"
+          >
+            <p>
+              This part runs on its own. The weather over Atlanta, the last
+              track I played, and what I'm reading all update through the day.
+              The short dispatch up top is written each morning by AI from those
+              same signals, which is why it talks about me in the third person.
+              It's the moving water from the line above, made literal.
+            </p>
+          </Disclosure>
+
+          <div className="u-rise u-rise-1 mt-8">
+            <AboutBlurb />
+          </div>
+
+          <div className="u-rise u-rise-2 mt-8 grid gap-6 md:grid-cols-2">
             <WeatherWidget />
             <SpotifyWidget />
           </div>
 
-          <div className="mt-6">
+          <div className="u-rise u-rise-2 mt-6">
             <FeedlyArticlesWidget />
           </div>
         </div>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -82,8 +82,7 @@ export default function AboutPage() {
             </p>
             <p className="font-[family-name:var(--font-instrument-serif)] text-xl italic text-[var(--u-ink-strong)]">
               This site is a small experiment in that idea: a calm surface over
-              a lot of moving water. Below is some of that water, the parts of
-              my days that move on their own.
+              a lot of moving water.
             </p>
           </div>
 
@@ -101,16 +100,17 @@ export default function AboutPage() {
               </li>
             ))}
           </ul>
-        </div>
-      </section>
 
-      <section className="container mx-auto max-w-4xl px-4 pb-16">
-        <div className="read-veil">
-          <h2 className="u-title text-4xl md:text-5xl">Right now</h2>
+          <h2 className="u-title mt-16 text-4xl md:text-5xl">Right now</h2>
+
+          <div className="u-rise u-rise-1 mt-8">
+            <AboutBlurb />
+          </div>
 
           <Disclosure
-            className="u-rise u-rise-1 mt-4"
+            className="u-rise u-rise-1 mt-3"
             label="Wait, what is this?"
+            align="right"
           >
             <p>
               This part runs on its own. The weather over Atlanta, the last
@@ -120,10 +120,6 @@ export default function AboutPage() {
               It's the moving water from the line above, made literal.
             </p>
           </Disclosure>
-
-          <div className="u-rise u-rise-1 mt-8">
-            <AboutBlurb />
-          </div>
 
           <div className="u-rise u-rise-2 mt-8 grid gap-6 md:grid-cols-2">
             <WeatherWidget />

--- a/src/app/components/AboutBlurb.tsx
+++ b/src/app/components/AboutBlurb.tsx
@@ -16,9 +16,6 @@ export default async function AboutBlurb() {
       <p className="font-[family-name:var(--font-instrument-serif)] text-2xl italic leading-relaxed text-[var(--u-ink-strong)] md:text-3xl">
         {blurb ?? "Loading..."}
       </p>
-      <figcaption className="mt-4 font-mono text-[0.7rem] uppercase tracking-[0.18em] text-[var(--u-accent)]">
-        Today, in brief
-      </figcaption>
     </figure>
   );
 }

--- a/src/components/Disclosure.tsx
+++ b/src/components/Disclosure.tsx
@@ -7,39 +7,45 @@ import { type ReactNode, useId, useState } from "react";
  * link rather than a chrome button; the panel animates to its natural height
  * via a grid-template-rows transition (no magic max-height) and respects
  * prefers-reduced-motion. Content stays mounted so the close animation can run
- * and aria-controls always resolves.
+ * and aria-controls always resolves. Set align="right" to right-bias the
+ * trigger and the revealed panel.
  */
 export default function Disclosure({
   label,
   children,
   className,
+  align = "left",
 }: {
   label: string;
   children: ReactNode;
   className?: string;
+  align?: "left" | "right";
 }) {
   const [open, setOpen] = useState(false);
   const regionId = useId();
+  const alignRight = align === "right";
 
   return (
     <div className={className}>
-      <button
-        type="button"
-        aria-expanded={open}
-        aria-controls={regionId}
-        onClick={() => setOpen((v) => !v)}
-        className="inline-flex items-center gap-2 font-[family-name:var(--font-instrument-serif)] text-lg italic text-[var(--u-accent)] underline decoration-1 underline-offset-4 transition-colors hover:text-[var(--u-accent-strong)]"
-      >
-        {label}
-        <span
-          aria-hidden="true"
-          className={`inline-block transition-transform ${
-            open ? "rotate-90" : ""
-          }`}
+      <div className={alignRight ? "flex justify-end" : undefined}>
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={regionId}
+          onClick={() => setOpen((v) => !v)}
+          className="inline-flex items-center gap-2 font-[family-name:var(--font-instrument-serif)] text-lg italic text-[var(--u-accent)] underline decoration-1 underline-offset-4 transition-colors hover:text-[var(--u-accent-strong)]"
         >
-          ›
-        </span>
-      </button>
+          {label}
+          <span
+            aria-hidden="true"
+            className={`inline-block transition-transform ${
+              open ? "rotate-90" : ""
+            }`}
+          >
+            ›
+          </span>
+        </button>
+      </div>
 
       <div
         id={regionId}
@@ -49,7 +55,11 @@ export default function Disclosure({
         className="disclosure-region"
       >
         <div className="disclosure-region__inner">
-          <div className="mt-3 max-w-2xl text-lg leading-relaxed text-[var(--u-ink-muted)]">
+          <div
+            className={`mt-3 max-w-2xl text-lg leading-relaxed text-[var(--u-ink-muted)] ${
+              alignRight ? "ml-auto" : ""
+            }`}
+          >
             {children}
           </div>
         </div>

--- a/src/components/Disclosure.tsx
+++ b/src/components/Disclosure.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { type ReactNode, useId, useState } from "react";
+
+/**
+ * Disclosure: a calm inline expand/collapse. The trigger reads as an accent
+ * link rather than a chrome button; the panel animates to its natural height
+ * via a grid-template-rows transition (no magic max-height) and respects
+ * prefers-reduced-motion. Content stays mounted so the close animation can run
+ * and aria-controls always resolves.
+ */
+export default function Disclosure({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const regionId = useId();
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={regionId}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-2 font-[family-name:var(--font-instrument-serif)] text-lg italic text-[var(--u-accent)] underline decoration-1 underline-offset-4 transition-colors hover:text-[var(--u-accent-strong)]"
+      >
+        {label}
+        <span
+          aria-hidden="true"
+          className={`inline-block transition-transform ${
+            open ? "rotate-90" : ""
+          }`}
+        >
+          ›
+        </span>
+      </button>
+
+      <div
+        id={regionId}
+        role="region"
+        aria-label={label}
+        data-open={open}
+        className="disclosure-region"
+      >
+        <div className="disclosure-region__inner">
+          <div className="mt-3 max-w-2xl text-lg leading-relaxed text-[var(--u-ink-muted)]">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -393,3 +393,35 @@
     animation: none;
   }
 }
+
+/* =========================================================================
+ * Inline disclosure ("Wait, what is this?"). The panel height animates to the
+ * content's natural size via grid-template-rows, so there is no magic
+ * max-height to maintain; the inner wrapper fades in for polish.
+ * ========================================================================= */
+.disclosure-region {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.4s cubic-bezier(0, 0, 0.2, 1);
+}
+
+.disclosure-region[data-open="true"] {
+  grid-template-rows: 1fr;
+}
+
+.disclosure-region__inner {
+  overflow: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease 0.05s;
+}
+
+.disclosure-region[data-open="true"] .disclosure-region__inner {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .disclosure-region,
+  .disclosure-region__inner {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
Restructures the about page to improve information hierarchy and readability. Removes the static principles grid, reorganizes biographical content, and introduces a new `Disclosure` component for progressive disclosure of contextual information about the Daily Profile section.

## Key Changes

- **Removed static principles section**: Deleted the hardcoded "Mission first," "Simple scales," and "Respect attention" grid from the about page
- **Reorganized biographical content**: Consolidated and reordered paragraphs to flow more naturally, moving the "craft underneath" discussion earlier and removing redundancy
- **Created new `Disclosure` component** (`src/components/Disclosure.tsx`):
  - Accessible expand/collapse widget with proper ARIA attributes (`aria-expanded`, `aria-controls`, `role="region"`)
  - Smooth height animation using CSS Grid `grid-template-rows` transition (no magic max-height)
  - Respects `prefers-reduced-motion` for accessibility
  - Styled as an italic accent link with chevron indicator
  - Content stays mounted for proper close animation
- **Added disclosure styles** to `src/pages.css` with smooth grid-based animation and fade-in effect for inner content
- **Restructured Daily Profile section**:
  - Simplified heading hierarchy (removed eyebrow + lede pattern)
  - Added disclosure widget explaining the auto-updating nature of the profile data
  - Moved `AboutBlurb` component inside the section with proper spacing classes
  - Added `u-rise` animation classes to widgets for visual consistency
- **Minor copy refinements**: Updated phrasing in bio and removed caption from `AboutBlurb` component

## Implementation Details

The `Disclosure` component uses a `useId` hook to generate unique IDs for proper ARIA `aria-controls` linking. The animation strategy avoids the common pitfall of magic `max-height` values by using CSS Grid's `grid-template-rows: 0fr` → `1fr` transition, which animates to the content's natural height. The inner wrapper's opacity transition is delayed slightly (0.05s) for a polished staggered effect.

https://claude.ai/code/session_01SzZ8m1gTteoDKkFd5CKNcz