### PR TITLE
[codex] Add more hobby projects

### DIFF
--- a/__tests__/lib/data/content.test.ts
+++ b/__tests__/lib/data/content.test.ts
@@ -48,8 +48,11 @@ describe("Keystatic content loader", () => {
       "boulevard-run",
       "paper-route",
       "jason-makes",
+      "kol",
+      "freewriter",
       "pixoo-timer",
       "little-broomstick-tales",
+      "feedly-sync",
       "inkscribe",
     ]);
   });

--- a/__tests__/next-config.test.ts
+++ b/__tests__/next-config.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import nextConfig from "../next.config";
+
+describe("Next.js config", () => {
+  it("traces filesystem content for routed collections", () => {
+    expect(nextConfig.outputFileTracingIncludes).toMatchObject({
+      "/articles": ["./content/articles/**/*"],
+      "/articles/[slug]": ["./content/articles/**/*"],
+      "/case-studies": ["./content/case-studies/**/*"],
+      "/case-studies/[slug]": ["./content/case-studies/**/*"],
+      "/hobbies": ["./content/hobby-projects/**/*"],
+      "/hobbies/[slug]": ["./content/hobby-projects/**/*"],
+    });
+  });
+});

--- a/content/hobby-projects/feedly-sync.mdx
+++ b/content/hobby-projects/feedly-sync.mdx
@@ -1,0 +1,40 @@
+---
+title: "Feedly Sync"
+slug: feedly-sync
+excerpt: "An Obsidian plugin that pulls public Feedly boards into a vault as cleaned-up Markdown articles."
+publishDate: 2026-06-13
+projectType: "Obsidian plugin"
+status: "Usable"
+builtWith:
+  - Obsidian API
+  - TypeScript
+  - Feedly public streams
+  - Turndown
+  - Defuddle
+highlights:
+  - "Syncs selected public Feedly boards into configured Obsidian folders."
+  - "Deduplicates articles with Feedly IDs and supports incremental sync by board."
+  - "Fetches article bodies, extracts readable content, and writes Markdown with frontmatter."
+sortOrder: 8
+tags:
+  - Obsidian
+  - Feedly
+  - Reading
+  - Automation
+---
+
+## Why I Built It
+
+Feedly Sync came from wanting saved articles to land somewhere durable instead of staying trapped in a feed reader.
+
+Feedly is useful for capture and triage. Obsidian is better for longer-term reading, linking, and writing. The plugin bridges those roles by turning Feedly board items into Markdown files inside a vault.
+
+## How It Works
+
+The plugin accepts public Feedly board URLs, parses the stream identifiers, and fetches articles through Feedly's public stream endpoints. Each configured board has its own destination folder, last sync timestamp, and optional force-full-sync setting.
+
+For each article, the plugin resolves the original URL where it can, extracts readable content, converts HTML to Markdown, generates frontmatter, and writes the note into the vault. It also checks existing notes by Feedly ID and URL so repeated syncs do not create duplicate articles.
+
+## What I Like About It
+
+This is a practical piece of reading infrastructure. It takes a behavior that already exists, saving articles, and makes the output more useful by moving it into the same place as notes and writing.

--- a/content/hobby-projects/freewriter.mdx
+++ b/content/hobby-projects/freewriter.mdx
@@ -1,0 +1,39 @@
+---
+title: "Freewriter"
+slug: freewriter
+excerpt: "An Obsidian plugin that turns the editor into a focused writing surface with hidden chrome, centered text, and typewriter scrolling."
+publishDate: 2026-06-13
+projectType: "Obsidian plugin"
+status: "Usable"
+builtWith:
+  - Obsidian API
+  - CodeMirror 6
+  - TypeScript
+  - esbuild
+highlights:
+  - "Creates a distraction-free writing mode inside an existing Obsidian vault."
+  - "Uses CodeMirror compartments so focus features can be toggled cleanly."
+  - "Supports typewriter scrolling, focus highlighting, custom width, and typography controls."
+sortOrder: 5
+tags:
+  - Obsidian
+  - Writing
+  - TypeScript
+  - Notes
+---
+
+## Why I Built It
+
+Freewriter exists because sometimes Obsidian is the right place to write, but the full Obsidian interface is not the right surface for writing.
+
+The goal is to keep the benefits of a real vault while making the act of drafting feel closer to a dedicated writing app: less chrome, less visual noise, a centered column, and the current line staying in a comfortable position.
+
+## How It Works
+
+The plugin is built with TypeScript against the Obsidian API and CodeMirror 6. It registers Freewrite mode as a command and uses CodeMirror compartments to turn editor behavior on and off without rebuilding the editor.
+
+The implementation separates the core mode controller from smaller pieces for typewriter scrolling, focus highlighting, cursor behavior, platform checks, settings, and the status indicator. CSS variables carry the user-facing typography and layout settings into the editor surface.
+
+## What I Like About It
+
+This is the kind of small personal tool that earns its keep by removing friction. It does not need to be a platform. It just makes one repeated activity feel better.

--- a/content/hobby-projects/inkscribe.mdx
+++ b/content/hobby-projects/inkscribe.mdx
@@ -14,7 +14,7 @@ highlights:
   - "Captures handwritten notes on mobile or desktop and saves the source image."
   - "Creates Markdown notes with configurable folders, filenames, and frontmatter."
   - "Makes analog capture fit into an existing Obsidian workflow."
-sortOrder: 6
+sortOrder: 9
 tags:
   - Obsidian
   - Claude

--- a/content/hobby-projects/kol.mdx
+++ b/content/hobby-projects/kol.mdx
@@ -1,0 +1,39 @@
+---
+title: "Kol"
+slug: kol
+excerpt: "A SwiftUI iOS practice app for learning blessings with word-by-word highlighting, phonetics, and follow-along audio."
+publishDate: 2026-06-13
+projectType: "iOS app"
+status: "Prototype"
+builtWith:
+  - SwiftUI
+  - AVFoundation
+  - Xcode
+  - Custom word timing data
+highlights:
+  - "Turns blessings into a guided practice flow instead of a static text reference."
+  - "Supports follow-along audio, word practice, phonetics, and completion states."
+  - "Uses timestamp data to highlight each word as the audio plays."
+sortOrder: 4
+tags:
+  - iOS
+  - SwiftUI
+  - Learning
+  - Family
+---
+
+## Why I Built It
+
+Kol is a small iOS app for practicing Jewish blessings in a way that feels calmer and more useful than reading from a static page.
+
+The first content set is Hanukkah blessings, but the structure points toward a broader practice app: choose a package, pick a blessing, follow the words, and use phonetics when the transliteration alone is not enough.
+
+## How It Works
+
+The app is built in SwiftUI with a compact model layer for prayers, words, audio metadata, and practice modes. Each blessing is represented as an ordered set of words with transliteration, optional phonetics, phrase breaks, translations, and notes.
+
+The teleprompter view has two practice modes. Follow Along mode plays bundled audio and highlights words based on timestamp JSON. Word Practice mode lets the user tap individual words to hear their segments. AVFoundation handles playback, while a view model maps audio time to the active word and drives the SwiftUI state.
+
+## What I Like About It
+
+Kol is interesting because it combines personal software, language learning, and a very specific use case. It is not trying to be a broad education platform. It is a small tool for making a ritual easier to practice.

--- a/content/hobby-projects/little-broomstick-tales.mdx
+++ b/content/hobby-projects/little-broomstick-tales.mdx
@@ -15,7 +15,7 @@ highlights:
   - "Keeps reusable game logic organized under a dedicated game folder."
 liveUrl: "https://little-broomstick-tales.vercel.app"
 repoUrl: "https://github.com/jrelgin/little-broomstick-tales"
-sortOrder: 5
+sortOrder: 7
 tags:
   - Games
   - Phaser

--- a/content/hobby-projects/pixoo-timer.mdx
+++ b/content/hobby-projects/pixoo-timer.mdx
@@ -15,7 +15,7 @@ highlights:
   - "Falls back to a floating Mac window when the Pixoo display is unavailable."
   - "Saves and restores the Pixoo channel after sending rendered timer frames."
 repoUrl: "https://github.com/jrelgin/PixooTimer"
-sortOrder: 4
+sortOrder: 6
 tags:
   - macOS
   - SwiftUI

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,8 @@ const nextConfig: NextConfig = {
     "/articles/[slug]": ["./content/articles/**/*"],
     "/case-studies": ["./content/case-studies/**/*"],
     "/case-studies/[slug]": ["./content/case-studies/**/*"],
+    "/hobbies": ["./content/hobby-projects/**/*"],
+    "/hobbies/[slug]": ["./content/hobby-projects/**/*"],
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Summary
- add Kol, Freewriter, and Feedly Sync to the hobbies collection
- update hobby project sort order so Kol and Freewriter appear higher in the list
- extend the content loader ordering test for the expanded project set

## Test Plan
- `pnpm test __tests__/lib/data/content.test.ts`
- `pnpm exec biome check __tests__/lib/data/content.test.ts`
- `pnpm build`

## Notes
- Repo links are intentionally omitted for these entries while the source repos are still private or awaiting public-readiness cleanup.
