### PR TITLE
[codex] Remove trailing list row dividers

### DIFF
--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -191,6 +191,10 @@
   transition: padding-left 0.3s cubic-bezier(0, 0, 0.2, 1);
 }
 
+li:last-child > .index-row {
+  border-bottom: 0;
+}
+
 .index-row:hover {
   padding-left: 0.6rem;
 }


### PR DESCRIPTION
## Summary
- Remove the bottom border from the final editorial index row on listing pages.
- Preserve the list top border and separators between non-final rows.

Closes #104

## Why
The list row component applied `border-bottom` to every `.index-row`, which left an extra trailing horizontal rule after the final row on article, case study, and hobby listing pages.

## Validation
- `pnpm exec biome check src/styles/pages.css` passed.
- `pnpm build` passed. It completed with existing KV DNS warnings for `driving-polliwog-29813.upstash.io` during static generation.
- Browser-verified `/articles`, `/case-studies`, and `/hobbies`: final row border is `0px`, interior rows still have `1px`, and the list top border remains.

## Known unrelated issue
- `pnpm lint` fails on pre-existing formatting diagnostics in `.vercel/project.json` and `.claude/settings.local.json`, outside this PR's changed file.