### PR TITLE
Simplify About page external links to GitHub and LinkedIn

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -9,9 +9,7 @@ export const metadata = {
 
 const elsewhere = [
   { label: "GitHub", href: "https://github.com/jrelgin" },
-  { label: "Email", href: "mailto:jason@signallantern.com" },
-  { label: "Signal Lantern", href: "https://signallantern.com" },
-  { label: "FullStory", href: "https://fullstory.com" },
+  { label: "LinkedIn", href: "https://www.linkedin.com/in/jrelgin" },
 ];
 
 export default function AboutPage() {


### PR DESCRIPTION
Reduce the bottom external-link row to just GitHub and LinkedIn,
removing the Email, Signal Lantern, and FullStory entries. Inline
body-copy links remain unchanged.

Closes #100

https://claude.ai/code/session_01CkJz6h64nev7ZQuv2X8dVG