### PR TITLE
Tune drop-cap alignment and scope it to articles and case studies

### DIFF
--- a/src/app/hobbies/[slug]/page.tsx
+++ b/src/app/hobbies/[slug]/page.tsx
@@ -137,7 +137,7 @@ export default async function Page({ params }: Params) {
             </div>
           )}
 
-          <div className="ink-prose ink-prose--dropcap u-rise u-rise-2 mt-12">
+          <div className="ink-prose u-rise u-rise-2 mt-12">
             <Markdown source={hobbyProject.content} />
           </div>
         </div>

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -369,14 +369,47 @@ li:last-child > .index-row {
   padding: 0;
 }
 
+/* Drop cap: a large initial letter on the first paragraph of long-form copy.
+ * Modern browsers use `initial-letter`, which sinks the glyph an exact number
+ * of lines and aligns its cap-height to the first line and its baseline to the
+ * Nth line automatically. Firefox (no `initial-letter` support) falls back to a
+ * tuned `float` recipe below. */
 .ink-prose--dropcap > p:first-of-type::first-letter {
   font-family: var(--font-gloock), serif;
-  float: left;
-  font-size: 3.6em;
-  line-height: 0.76;
-  padding-right: 0.09em;
-  margin-top: 0.04em;
   color: var(--u-accent);
+  -webkit-initial-letter: 3;
+  initial-letter: 3;
+  margin-right: 0.09em;
+}
+
+/* Float fallback for browsers without `initial-letter` (notably Firefox).
+ * With base prose at 1.12rem / line-height 1.8, three line boxes ≈ 6.05rem.
+ * font-size 3.35em with line-height 0.74 seats the cap-height against the first
+ * line and drops the baseline onto the third line. */
+@supports not (initial-letter: 3) {
+  .ink-prose--dropcap > p:first-of-type::first-letter {
+    float: left;
+    font-size: 3.35em;
+    line-height: 0.74;
+    margin-top: 0.02em;
+    margin-right: 0.09em;
+  }
+}
+
+/* Reduce the cap to two lines on small screens so it does not crowd the
+ * tighter line wrapping. */
+@media (max-width: 767px) {
+  .ink-prose--dropcap > p:first-of-type::first-letter {
+    -webkit-initial-letter: 2;
+    initial-letter: 2;
+  }
+
+  @supports not (initial-letter: 2) {
+    .ink-prose--dropcap > p:first-of-type::first-letter {
+      font-size: 2.55em;
+      line-height: 0.78;
+    }
+  }
 }
 
 /* =========================================================================


### PR DESCRIPTION
Closes #107

## What & why
The long-form drop cap overhung the first row and didn't land on a baseline, so it read as accidental. This refines it to sink an exact number of text lines and aligns cleanly, per Jason's direction in the issue ("equal to a number of text lines so it all looks intentional… do what a designer would do").

## Changes
- **`src/styles/pages.css`** — rework the `.ink-prose--dropcap` rule:
  - Primary path uses the modern CSS `initial-letter` property, which sinks the glyph an exact number of lines and aligns its cap-height to line 1 and its baseline to the Nth line automatically (best-practice, designerly result). **3 lines** on desktop.
  - `@supports not (initial-letter: 3)` fallback keeps a tuned `float` recipe for browsers without support (notably Firefox), sized to ~3 line boxes.
  - `@media (max-width: 767px)` reduces the cap to **2 lines** so it doesn't crowd tighter mobile line-wrapping (with a matching float fallback).
  - Color is unchanged — still the theme-aware `var(--u-accent)`, so day (Hokusai) and night (Twilight) both stay correct.
- **`src/app/hobbies/[slug]/page.tsx`** — remove `ink-prose--dropcap` so the drop cap now appears **only on articles and case studies**, not hobby pages.

## Decisions (from Jason's answers in #107)
- Size: close to current but a whole number of lines → 3 lines desktop / 2 mobile.
- Scope: articles + case studies only → removed from hobbies.
- Color: unchanged.
- Mobile: reduced.

## Verification
- `pnpm lint` — passes.
- `pnpm build` — compiles and statically generates all 22 pages (articles, case studies, hobbies) when env secrets are provided. *(Build only fails in the sandbox on missing API secrets — `KEYSTATIC_*`, `OPENAI_API_KEY`, etc. — which are unrelated to this CSS/markup change; confirmed clean once placeholder values are supplied.)*
- Rendered-HTML check on the dev server: articles and case studies retain `ink-prose--dropcap`; `/hobbies/*` no longer has it.

⚠️ **Note:** No headless browser was available in this environment, so I could not take before/after screenshots to pixel-tune the **`float` fallback** values (Firefox-only path). The `initial-letter` path (Chrome/Safari/Edge) is self-aligning by spec and needs no tuning. Please eyeball the Firefox rendering on an article and a case study, day and night, desktop and mobile — happy to nudge the fallback `font-size`/`line-height` if anything reads slightly off.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiaiqfpBT4VmXvv1NCJPty)_