### PR TITLE
Add mobile full-screen navigation menu (#106)

### DIFF
--- a/lib/config/navigation.ts
+++ b/lib/config/navigation.ts
@@ -10,7 +10,7 @@ export type NavItem = {
 
 export const NAVIGATION_ITEMS: NavItem[] = [
   { label: "About", href: "/about", match: "exact" },
-  { label: "Case Studies", href: "/case-studies" },
-  { label: "Hobbies", href: "/hobbies" },
   { label: "Articles", href: "/articles" },
+  { label: "Hobbies", href: "/hobbies" },
+  { label: "Case Studies", href: "/case-studies" },
 ];

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -738,6 +738,35 @@ body {
   }
 }
 
+/* Mobile full-screen nav overlay. Stays mounted so the close animation can run
+   and aria-controls always resolves; visibility is delayed until the fade-out
+   finishes so links aren't focusable while hidden. Uses the same ease-out-expo
+   curve as the daily-profile overlay so it feels native to the site. */
+.mobile-nav-overlay {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-8px);
+  transition: opacity 260ms cubic-bezier(0.19, 1, 0.22, 1),
+    transform 260ms cubic-bezier(0.19, 1, 0.22, 1),
+    visibility 0s linear 260ms;
+}
+
+.mobile-nav-overlay[data-open="true"] {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition: opacity 260ms cubic-bezier(0.19, 1, 0.22, 1),
+    transform 260ms cubic-bezier(0.19, 1, 0.22, 1), visibility 0s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-nav-overlay {
+    transition: visibility 0s linear 0ms;
+  }
+}
+
 /* The homepage is a single fixed canvas that never scrolls. Lock overflow at
    all widths so the 100vw scene can't create a scrollbar (and so mobile 100dvh
    transitions don't leak a few px of scroll). overflow:hidden keeps <html> a

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 import {
   LEGACY_THEME_STORAGE_KEY,
@@ -23,6 +23,10 @@ import { isNavItemActive } from "#lib/utils/navigation";
 export default function Navigation() {
   const pathname = usePathname();
   const [theme, setTheme] = useState<SiteTheme>("hokusai");
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuId = useId();
+  const menuPanelRef = useRef<HTMLDivElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const initialTheme = resolveSiteTheme();
@@ -75,13 +79,44 @@ export default function Navigation() {
     setStoredSiteTheme(nextTheme);
   }, [theme]);
 
+  // Close the mobile menu whenever the route changes so navigating always
+  // dismisses it (even when the destination is the current page).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: close on path change
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [pathname]);
+
+  // While the mobile menu is open: lock background scroll, close on Escape, and
+  // move focus into the panel (restoring it to the trigger on close).
+  useEffect(() => {
+    if (!menuOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMenuOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+
+    menuPanelRef.current?.focus();
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+      menuButtonRef.current?.focus();
+    };
+  }, [menuOpen]);
+
   const nextThemeLabel = theme === "twilight" ? "day" : "night";
   const isTwilight = theme === "twilight";
   const shouldInvertLogo = isTwilight && pathname !== "/";
 
   return (
     <nav className="pointer-events-none fixed inset-x-0 top-0 z-50 px-4 pt-4 md:px-10 md:pt-10">
-      <div className="flex items-start justify-between gap-3">
+      <div className="relative z-50 flex items-start justify-between gap-3">
         <Link
           href="/"
           aria-label="Jason Makes home"
@@ -103,7 +138,7 @@ export default function Navigation() {
         </Link>
 
         <div className="pointer-events-auto flex items-center rounded border border-white/15 bg-slate-950/95 p-1 text-[10px] font-semibold uppercase text-white shadow-xl backdrop-blur-sm sm:text-xs">
-          <ul className="flex items-center">
+          <ul className="hidden items-center md:flex">
             {NAVIGATION_ITEMS.map((item) => {
               const isActive = isNavItemActive(pathname, item);
               return (
@@ -123,7 +158,7 @@ export default function Navigation() {
               );
             })}
           </ul>
-          <div className="mx-1 h-5 w-px bg-white/15" />
+          <div className="mx-1 hidden h-5 w-px bg-white/15 md:block" />
           <button
             type="button"
             aria-label={`Switch to ${nextThemeLabel} theme`}
@@ -133,7 +168,50 @@ export default function Navigation() {
           >
             {theme === "twilight" ? <SunIcon /> : <SeaCreatureIcon />}
           </button>
+          <button
+            ref={menuButtonRef}
+            type="button"
+            aria-label={menuOpen ? "Close menu" : "Open menu"}
+            aria-expanded={menuOpen}
+            aria-controls={menuId}
+            onClick={() => setMenuOpen((open) => !open)}
+            className="flex min-h-8 min-w-8 cursor-pointer items-center justify-center rounded text-white/80 transition hover:bg-white/10 hover:text-white sm:min-h-9 sm:min-w-9 md:hidden"
+          >
+            {menuOpen ? <CloseIcon /> : <MenuIcon />}
+          </button>
         </div>
+      </div>
+
+      <div
+        id={menuId}
+        ref={menuPanelRef}
+        tabIndex={-1}
+        aria-hidden={!menuOpen}
+        data-open={menuOpen}
+        className="mobile-nav-overlay fixed inset-0 z-40 flex flex-col items-center justify-center gap-2 bg-slate-950/95 backdrop-blur-sm md:hidden"
+      >
+        <ul className="flex w-full flex-col items-center gap-2 text-lg font-semibold uppercase tracking-wide text-white">
+          {NAVIGATION_ITEMS.map((item) => {
+            const isActive = isNavItemActive(pathname, item);
+            return (
+              <li key={item.href} className="w-full max-w-xs">
+                <Link
+                  href={item.href}
+                  onClick={() => setMenuOpen(false)}
+                  aria-current={isActive ? "page" : undefined}
+                  className={cn(
+                    "flex min-h-12 items-center justify-center rounded px-4 transition",
+                    isActive
+                      ? "bg-white text-slate-950"
+                      : "text-white/70 hover:bg-white/10 hover:text-white",
+                  )}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
       </div>
     </nav>
   );
@@ -161,6 +239,45 @@ function SunIcon() {
       <path d="M20 12h2" />
       <path d="m6.34 17.66-1.41 1.41" />
       <path d="m19.07 4.93-1.41 1.41" />
+    </svg>
+  );
+}
+
+function MenuIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    >
+      <path d="M3 6h18" />
+      <path d="M3 12h18" />
+      <path d="M3 18h18" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    >
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
     </svg>
   );
 }


### PR DESCRIPTION
Closes #106.

## What changed
Below the `md` (768px) breakpoint, the desktop nav links now collapse into a hamburger button that opens an accessible **full-screen menu**. Desktop/tablet keep the existing horizontal pill unchanged.

Implements Jason's answers from the issue:
- **Pattern:** full-screen menu on phones; desktop/tablet untouched.
- **Theme toggle:** stays visible in the bar beside the hamburger (not hidden inside the menu).
- **Styling:** reuses the existing dark nav styling (`bg-slate-950/95`, white text) — does not adapt to the light/dark site theme.
- **Nav order (everywhere):** changed to **About → Articles → Hobbies → Case Studies** in `lib/config/navigation.ts`, so both desktop and mobile pick it up.
- **Animation:** simple/quick fade + slide using the site's existing ease-out-expo curve `cubic-bezier(0.19, 1, 0.22, 1)` (the same one the daily-profile overlay uses), with a `prefers-reduced-motion` guard.

## Accessibility
- Hamburger button with `aria-expanded` / `aria-controls` and a dynamic `aria-label` (Open/Close menu).
- **Escape** closes the menu; selecting a route closes it; route changes auto-dismiss it.
- Focus moves into the panel on open and returns to the hamburger on close.
- Panel stays mounted (so the close animation runs and `aria-controls` always resolves); `visibility` is delayed until the fade-out completes so links aren't focusable while hidden. Background scroll is locked while open.
- Links reuse `NAVIGATION_ITEMS` and `isNavItemActive` (with `aria-current="page"` on the active route) — no duplicated link list.

## Stacking / layout notes
- The top bar is `relative z-50`; the overlay is `z-40`, so the logo, theme toggle, and close (X) button remain above the overlay and clickable while it's open.
- Every interactive element keeps `pointer-events-auto` (the root `<nav>` is `pointer-events-none`); the overlay enables pointer events only when open.

## Verification
- `pnpm lint` — passes.
- `pnpm build` — compiles and type-checks; full static build succeeds (sandbox required placeholder secrets for unrelated API routes).
- `pnpm test` — all 31 tests pass.

Files: `src/components/Navigation.tsx`, `lib/config/navigation.ts`, `src/app/globals.css`.

https://claude.ai/code/session_015RKhRj2V4pR3kRGFBSKQ5a

---
_Generated by [Claude Code](https://claude.ai/code/session_015RKhRj2V4pR3kRGFBSKQ5a)_