### PR TITLE
Audit + test the device-color-scheme theme default (#105)

### DIFF
--- a/__tests__/lib/site-theme.test.ts
+++ b/__tests__/lib/site-theme.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  LEGACY_THEME_STORAGE_KEY,
+  SITE_THEME_CHANGE_EVENT,
+  SITE_THEME_STORAGE_KEY,
+  applySiteTheme,
+  getSystemSiteTheme,
+  isSiteTheme,
+  readStoredSiteTheme,
+  resolveSiteTheme,
+  setStoredSiteTheme,
+} from "../../src/lib/site-theme";
+
+/**
+ * Stub `window.matchMedia` so tests can simulate the visitor's OS
+ * `prefers-color-scheme` setting. `prefersDark` controls whether the dark query
+ * matches.
+ */
+function mockMatchMedia(prefersDark: boolean) {
+  const matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes("dark") ? prefersDark : !prefersDark,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+  }));
+  vi.stubGlobal("matchMedia", matchMedia);
+  window.matchMedia = matchMedia as unknown as typeof window.matchMedia;
+  return matchMedia;
+}
+
+describe("site-theme", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    // Reset any DOM theme state between tests.
+    document.documentElement.classList.remove("dark");
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.style.colorScheme = "";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("isSiteTheme", () => {
+    it("accepts the two known themes", () => {
+      expect(isSiteTheme("hokusai")).toBe(true);
+      expect(isSiteTheme("twilight")).toBe(true);
+    });
+
+    it("rejects null and unknown values", () => {
+      expect(isSiteTheme(null)).toBe(false);
+      expect(isSiteTheme("dark")).toBe(false);
+      expect(isSiteTheme("")).toBe(false);
+    });
+  });
+
+  describe("getSystemSiteTheme", () => {
+    it("returns twilight when the OS prefers dark", () => {
+      mockMatchMedia(true);
+      expect(getSystemSiteTheme()).toBe("twilight");
+    });
+
+    it("returns hokusai when the OS prefers light", () => {
+      mockMatchMedia(false);
+      expect(getSystemSiteTheme()).toBe("hokusai");
+    });
+  });
+
+  describe("readStoredSiteTheme", () => {
+    it("reads the primary storage key", () => {
+      window.localStorage.setItem(SITE_THEME_STORAGE_KEY, "twilight");
+      expect(readStoredSiteTheme()).toBe("twilight");
+    });
+
+    it("falls back to the legacy storage key", () => {
+      window.localStorage.setItem(LEGACY_THEME_STORAGE_KEY, "hokusai");
+      expect(readStoredSiteTheme()).toBe("hokusai");
+    });
+
+    it("prefers the primary key over the legacy key", () => {
+      window.localStorage.setItem(SITE_THEME_STORAGE_KEY, "hokusai");
+      window.localStorage.setItem(LEGACY_THEME_STORAGE_KEY, "twilight");
+      expect(readStoredSiteTheme()).toBe("hokusai");
+    });
+
+    it("returns null when nothing valid is stored", () => {
+      expect(readStoredSiteTheme()).toBeNull();
+    });
+
+    it("ignores garbage values in storage", () => {
+      window.localStorage.setItem(SITE_THEME_STORAGE_KEY, "not-a-theme");
+      window.localStorage.setItem(LEGACY_THEME_STORAGE_KEY, "also-bogus");
+      expect(readStoredSiteTheme()).toBeNull();
+    });
+  });
+
+  describe("resolveSiteTheme", () => {
+    it("follows a light OS when no preference is stored", () => {
+      mockMatchMedia(false);
+      expect(resolveSiteTheme()).toBe("hokusai");
+    });
+
+    it("follows a dark OS when no preference is stored", () => {
+      mockMatchMedia(true);
+      expect(resolveSiteTheme()).toBe("twilight");
+    });
+
+    it("lets a stored preference win over the system theme", () => {
+      mockMatchMedia(true); // OS prefers dark...
+      window.localStorage.setItem(SITE_THEME_STORAGE_KEY, "hokusai"); // ...but user chose light
+      expect(resolveSiteTheme()).toBe("hokusai");
+    });
+  });
+
+  describe("applySiteTheme", () => {
+    it("applies twilight as the dark scheme", () => {
+      applySiteTheme("twilight");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+      expect(document.documentElement.dataset.theme).toBe("twilight");
+      expect(document.documentElement.style.colorScheme).toBe("dark");
+    });
+
+    it("applies hokusai as the light scheme", () => {
+      applySiteTheme("twilight");
+      applySiteTheme("hokusai");
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+      expect(document.documentElement.dataset.theme).toBe("hokusai");
+      expect(document.documentElement.style.colorScheme).toBe("light");
+    });
+  });
+
+  describe("setStoredSiteTheme", () => {
+    it("persists to both storage keys", () => {
+      setStoredSiteTheme("twilight");
+      expect(window.localStorage.getItem(SITE_THEME_STORAGE_KEY)).toBe(
+        "twilight",
+      );
+      expect(window.localStorage.getItem(LEGACY_THEME_STORAGE_KEY)).toBe(
+        "twilight",
+      );
+    });
+
+    it("applies the chosen theme to the document", () => {
+      setStoredSiteTheme("twilight");
+      expect(document.documentElement.dataset.theme).toBe("twilight");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+    });
+
+    it("dispatches the theme-change event with the new theme", () => {
+      const listener = vi.fn();
+      window.addEventListener(SITE_THEME_CHANGE_EVENT, listener);
+
+      setStoredSiteTheme("hokusai");
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const event = listener.mock.calls[0][0] as CustomEvent<{
+        theme: string;
+      }>;
+      expect(event.detail.theme).toBe("hokusai");
+
+      window.removeEventListener(SITE_THEME_CHANGE_EVENT, listener);
+    });
+  });
+});

--- a/src/lib/site-theme.ts
+++ b/src/lib/site-theme.ts
@@ -29,6 +29,18 @@ export function readStoredSiteTheme(): SiteTheme | null {
   return isSiteTheme(legacyTheme) ? legacyTheme : null;
 }
 
+/**
+ * Resolve the active theme: an explicit, persisted choice always wins; with no
+ * stored preference the site follows the visitor's OS `prefers-color-scheme`.
+ *
+ * Product decision (issue #105): a two-state, persistent toggle. There is no
+ * stored preference until the visitor toggles manually, so first visits follow
+ * the device color scheme (and live OS changes are honored while no preference
+ * is stored — see the `matchMedia` listeners in Navigation/SeascapeCanvas). Once
+ * the visitor toggles, that choice persists across visits. The legacy
+ * `jasonmakes:home-theme` key is intentionally still honored so prior choices
+ * carry over (see `readStoredSiteTheme`).
+ */
 export function resolveSiteTheme(): SiteTheme {
   return readStoredSiteTheme() ?? getSystemSiteTheme();
 }


### PR DESCRIPTION
Closes #105.

## Summary

Issue #105 asked that day/night mode follow the visitor's OS `prefers-color-scheme` by default while preserving manual toggling, and explicitly framed it as "treat the current behavior as mostly implemented, then audit and verify it with explicit test cases."

**Audit result: the behavior was already implemented end-to-end** — so this PR is candidly an *audit + regression-coverage* change, not a behavior rewrite:

- `resolveSiteTheme()` returns `readStoredSiteTheme() ?? getSystemSiteTheme()`, so a first visit with no stored preference follows the device color scheme.
- The inline `themeInitScript` in `src/app/layout.tsx` mirrors this before hydration, preventing a wrong-theme flash.
- `Navigation.tsx` and `seascape-canvas.tsx` each register a `matchMedia` `change` listener that updates the theme **only when no preference is stored**, so live OS changes apply without a refresh but never override a manual choice.

The real gap was that **no automated tests guarded this**, and the product decision was unrecorded.

## Changes

- **`__tests__/lib/site-theme.test.ts`** (new) — explicit test cases tied to the acceptance criteria:
  - `isSiteTheme` validation.
  - `getSystemSiteTheme` → `twilight` on dark OS, `hokusai` on light OS.
  - `readStoredSiteTheme` → primary key, legacy-key fallback, `null` when absent, ignores garbage.
  - `resolveSiteTheme` → no-pref+light → `hokusai`; no-pref+dark → `twilight`; stored preference wins over system.
  - `applySiteTheme` → `.dark` class, `data-theme`, and `colorScheme` for both themes.
  - `setStoredSiteTheme` → writes both storage keys, applies to the DOM, dispatches `SITE_THEME_CHANGE_EVENT` with `detail.theme`.
- **`src/lib/site-theme.ts`** — doc comment near `resolveSiteTheme()` recording the product decision: a **two-state persistent toggle** (no third `system` mode), with the legacy `jasonmakes:home-theme` key intentionally still honored.

## Product decision

Kept the existing two-state persistent toggle (no stored preference = follow system live; a manual toggle persists across visits). Did **not** add a three-state `System / Day / Night` control or a reset-to-system affordance — those are larger product changes the issue lists only as open questions. Happy to take that on in a follow-up if you'd prefer the three-state UI.

## Verification

- `pnpm test` — 48 passing (17 new). ✅
- `pnpm lint` (Biome) — clean. ✅
- `pnpm build` — succeeds (with env vars present). ✅ *Note: in a secret-less sandbox the build only fails while collecting page data for the OpenAI/Keystatic API routes due to missing env vars — unrelated to this change; it builds green once placeholders are supplied.*
- Manual spot-check (DevTools "Emulate CSS prefers-color-scheme"): cleared storage + light OS → Hokusai, dark OS → Twilight, no flash; flipping the emulated scheme with no stored pref updates live; a manual toggle persists across reloads.

https://claude.ai/code/session_01SbZ5WDXyRxpQRUnWNXpp9J

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbZ5WDXyRxpQRUnWNXpp9J)_