### PR TITLE
Remove intro delay on dispatch panel and slow animation slightly

### DIFF
--- a/__tests__/components/DailyProfilePanel.test.tsx
+++ b/__tests__/components/DailyProfilePanel.test.tsx
@@ -51,7 +51,7 @@ describe("DailyProfilePanel", () => {
     expect(trigger.hasAttribute("disabled")).toBe(true);
 
     act(() => {
-      vi.advanceTimersByTime(1800);
+      vi.advanceTimersByTime(1);
     });
 
     expect(shell?.getAttribute("data-ready")).toBe("true");
@@ -59,7 +59,7 @@ describe("DailyProfilePanel", () => {
     expect(trigger.hasAttribute("disabled")).toBe(false);
 
     act(() => {
-      vi.advanceTimersByTime(1500);
+      vi.advanceTimersByTime(1900);
     });
 
     expect(shell?.getAttribute("data-entered")).toBe("true");

--- a/src/app/components/DailyProfilePanel.tsx
+++ b/src/app/components/DailyProfilePanel.tsx
@@ -19,8 +19,8 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(",");
 
-const INTRO_DELAY_MS = 1800;
-const INTRO_ANIMATION_MS = 1500;
+const INTRO_DELAY_MS = 0;
+const INTRO_ANIMATION_MS = 1900;
 const DETAILS_OPEN_DELAY_MS = 30;
 const DETAILS_EXIT_MS = 640;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,8 +71,8 @@ body {
   opacity: 0;
   pointer-events: none;
   transform: translate3d(0, 26px, 0) scale(0.985);
-  transition: opacity 1500ms cubic-bezier(0.19, 1, 0.22, 1), filter 1500ms
-    cubic-bezier(0.19, 1, 0.22, 1), transform 1500ms
+  transition: opacity 1900ms cubic-bezier(0.19, 1, 0.22, 1), filter 1900ms
+    cubic-bezier(0.19, 1, 0.22, 1), transform 1900ms
     cubic-bezier(0.19, 1, 0.22, 1), width 640ms
     cubic-bezier(0.19, 1, 0.22, 1);
 }


### PR DESCRIPTION
The bottom-right daily profile panel waited 1800ms before animating in.
Drop that delay to 0 so it begins entering as soon as the page mounts,
and bump the intro animation from 1500ms to 1900ms to slow it just a bit.