### PR TITLE
Add Day/Night/Auto theme control and larger mobile menu button

### DIFF
--- a/__tests__/components/theme-control.test.tsx
+++ b/__tests__/components/theme-control.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import ThemeControl from "../../src/components/theme-control";
+
+describe("ThemeControl", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the three theme options as radios", () => {
+    render(<ThemeControl value="system" onChange={() => {}} />);
+
+    expect(screen.getByRole("radio", { name: "Day" })).toBeTruthy();
+    expect(screen.getByRole("radio", { name: "Auto" })).toBeTruthy();
+    expect(screen.getByRole("radio", { name: "Night" })).toBeTruthy();
+  });
+
+  it("marks the selected preference as checked", () => {
+    render(<ThemeControl value="twilight" onChange={() => {}} />);
+
+    expect(
+      screen.getByRole("radio", { name: "Night" }).getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("radio", { name: "Day" }).getAttribute("aria-checked"),
+    ).toBe("false");
+  });
+
+  it("calls onChange with the matching preference on click", () => {
+    const onChange = vi.fn();
+    render(<ThemeControl value="system" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "Day" }));
+    expect(onChange).toHaveBeenCalledWith("hokusai");
+
+    fireEvent.click(screen.getByRole("radio", { name: "Night" }));
+    expect(onChange).toHaveBeenCalledWith("twilight");
+
+    fireEvent.click(screen.getByRole("radio", { name: "Auto" }));
+    expect(onChange).toHaveBeenCalledWith("system");
+  });
+
+  it("moves the selection with arrow keys", () => {
+    const onChange = vi.fn();
+    render(<ThemeControl value="system" onChange={onChange} />);
+
+    fireEvent.keyDown(screen.getByRole("radio", { name: "Auto" }), {
+      key: "ArrowRight",
+    });
+    expect(onChange).toHaveBeenCalledWith("twilight");
+
+    fireEvent.keyDown(screen.getByRole("radio", { name: "Auto" }), {
+      key: "ArrowLeft",
+    });
+    expect(onChange).toHaveBeenCalledWith("hokusai");
+  });
+});

--- a/__tests__/lib/site-theme.test.ts
+++ b/__tests__/lib/site-theme.test.ts
@@ -7,8 +7,11 @@ import {
   applySiteTheme,
   getSystemSiteTheme,
   isSiteTheme,
+  isSiteThemePreference,
+  readStoredPreference,
   readStoredSiteTheme,
   resolveSiteTheme,
+  setStoredPreference,
   setStoredSiteTheme,
 } from "../../src/lib/site-theme";
 
@@ -57,6 +60,20 @@ describe("site-theme", () => {
       expect(isSiteTheme(null)).toBe(false);
       expect(isSiteTheme("dark")).toBe(false);
       expect(isSiteTheme("")).toBe(false);
+    });
+  });
+
+  describe("isSiteThemePreference", () => {
+    it("accepts the two themes plus system", () => {
+      expect(isSiteThemePreference("hokusai")).toBe(true);
+      expect(isSiteThemePreference("twilight")).toBe(true);
+      expect(isSiteThemePreference("system")).toBe(true);
+    });
+
+    it("rejects null and unknown values", () => {
+      expect(isSiteThemePreference(null)).toBe(false);
+      expect(isSiteThemePreference("auto")).toBe(false);
+      expect(isSiteThemePreference("")).toBe(false);
     });
   });
 
@@ -115,6 +132,78 @@ describe("site-theme", () => {
       mockMatchMedia(true); // OS prefers dark...
       window.localStorage.setItem(SITE_THEME_STORAGE_KEY, "hokusai"); // ...but user chose light
       expect(resolveSiteTheme()).toBe("hokusai");
+    });
+
+    it("follows the OS when the stored preference is the literal system", () => {
+      mockMatchMedia(true);
+      window.localStorage.setItem(SITE_THEME_STORAGE_KEY, "system");
+      expect(resolveSiteTheme()).toBe("twilight");
+    });
+  });
+
+  describe("readStoredPreference", () => {
+    it("defaults to system when nothing is stored", () => {
+      expect(readStoredPreference()).toBe("system");
+    });
+
+    it("returns the literal system preference", () => {
+      window.localStorage.setItem(SITE_THEME_STORAGE_KEY, "system");
+      expect(readStoredPreference()).toBe("system");
+    });
+
+    it("returns an explicit stored theme", () => {
+      window.localStorage.setItem(SITE_THEME_STORAGE_KEY, "twilight");
+      expect(readStoredPreference()).toBe("twilight");
+    });
+
+    it("migrates a legacy explicit choice", () => {
+      window.localStorage.setItem(LEGACY_THEME_STORAGE_KEY, "hokusai");
+      expect(readStoredPreference()).toBe("hokusai");
+    });
+
+    it("defaults to system for garbage values", () => {
+      window.localStorage.setItem(SITE_THEME_STORAGE_KEY, "not-a-theme");
+      expect(readStoredPreference()).toBe("system");
+    });
+  });
+
+  describe("setStoredPreference", () => {
+    it("persists an explicit theme to both keys and applies it", () => {
+      setStoredPreference("twilight");
+      expect(window.localStorage.getItem(SITE_THEME_STORAGE_KEY)).toBe(
+        "twilight",
+      );
+      expect(window.localStorage.getItem(LEGACY_THEME_STORAGE_KEY)).toBe(
+        "twilight",
+      );
+      expect(document.documentElement.dataset.theme).toBe("twilight");
+    });
+
+    it("stores the literal system value but applies the resolved OS theme", () => {
+      mockMatchMedia(true); // OS prefers dark
+      setStoredPreference("system");
+      expect(window.localStorage.getItem(SITE_THEME_STORAGE_KEY)).toBe(
+        "system",
+      );
+      // isSiteTheme still treats "system" as no explicit theme...
+      expect(readStoredSiteTheme()).toBeNull();
+      // ...but the DOM gets the resolved OS theme.
+      expect(document.documentElement.dataset.theme).toBe("twilight");
+    });
+
+    it("dispatches the resolved theme for a system preference", () => {
+      mockMatchMedia(false); // OS prefers light
+      const listener = vi.fn();
+      window.addEventListener(SITE_THEME_CHANGE_EVENT, listener);
+
+      setStoredPreference("system");
+
+      const event = listener.mock.calls[0][0] as CustomEvent<{
+        theme: string;
+      }>;
+      expect(event.detail.theme).toBe("hokusai");
+
+      window.removeEventListener(SITE_THEME_CHANGE_EVENT, listener);
     });
   });
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -784,7 +784,9 @@ body {
 .theme-thumb-fill {
   position: absolute;
   inset: 0;
-  border-radius: 9999px;
+  /* Nest the marker's corners just inside the track's squared radius so it reads
+     as part of the same family as the nav, not a pill grafted on. */
+  border-radius: 0.125rem;
   /* Soft marker — readable against the lighter track but far less prominent
      than a solid pill, so it never pulls focus from the page. */
   background-color: rgb(255 255 255 / 0.18);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -767,6 +767,54 @@ body {
   }
 }
 
+/* Theme control: a single soft marker that glides between the three segments.
+   The outer .theme-thumb handles the slide; the inner .theme-thumb-fill carries
+   the low-weight pill and replays a brief squash as it travels, so the circle
+   appears to morph rather than teleport. Easing matches the nav overlay so the
+   motion feels native to the site. */
+.theme-thumb {
+  position: absolute;
+  top: 0.125rem;
+  bottom: 0.125rem;
+  left: 0.125rem;
+  transition: transform 440ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform;
+}
+
+.theme-thumb-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  /* Soft marker — readable against the lighter track but far less prominent
+     than a solid pill, so it never pulls focus from the page. */
+  background-color: rgb(255 255 255 / 0.18);
+}
+
+.theme-thumb-fill--morph {
+  animation: theme-thumb-morph 440ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes theme-thumb-morph {
+  0% {
+    transform: scaleX(1) scaleY(1);
+  }
+  40% {
+    transform: scaleX(1.28) scaleY(0.9);
+  }
+  100% {
+    transform: scaleX(1) scaleY(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .theme-thumb {
+    transition: none;
+  }
+  .theme-thumb-fill--morph {
+    animation: none;
+  }
+}
+
 /* The homepage is a single fixed canvas that never scrolls. Lock overflow at
    all widths so the 100vw scene can't create a scrollbar (and so mobile 100dvh
    transitions don't leak a few px of scroll). overflow:hidden keeps <html> a

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -74,6 +74,8 @@ const themeInitScript = `
     const legacyThemeKey = ${JSON.stringify(LEGACY_THEME_STORAGE_KEY)};
     const stored = localStorage.getItem(themeKey) || localStorage.getItem(legacyThemeKey);
     const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "twilight" : "hokusai";
+    // A stored "system" preference (or anything absent/invalid) intentionally
+    // falls through to systemTheme via this else branch — no special-casing needed.
     const theme = stored === "hokusai" || stored === "twilight" ? stored : systemTheme;
     document.documentElement.classList.toggle("dark", theme === "twilight");
     document.documentElement.dataset.theme = theme;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -165,9 +165,7 @@ export default function Navigation() {
               );
             })}
           </ul>
-          <div className="hidden h-6 w-px bg-white/15 md:block" />
           <ThemeControl value={preference} onChange={handlePreferenceChange} />
-          <div className="h-6 w-px bg-white/15 md:hidden" />
           <button
             ref={menuButtonRef}
             type="button"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -140,11 +140,11 @@ export default function Navigation() {
             width={132}
             height={72}
             priority
-            className={cn("h-8 w-auto sm:h-10", shouldInvertLogo && "invert")}
+            className={cn("h-10 w-auto", shouldInvertLogo && "invert")}
           />
         </Link>
 
-        <div className="pointer-events-auto flex items-center rounded border border-white/15 bg-slate-950/95 p-1 text-[10px] font-semibold uppercase text-white shadow-xl backdrop-blur-sm sm:text-xs">
+        <div className="pointer-events-auto flex items-center gap-1 rounded border border-white/15 bg-slate-950/95 p-1 text-xs font-semibold uppercase text-white shadow-xl backdrop-blur-sm sm:text-sm">
           <ul className="hidden items-center md:flex">
             {NAVIGATION_ITEMS.map((item) => {
               const isActive = isNavItemActive(pathname, item);
@@ -153,7 +153,7 @@ export default function Navigation() {
                   <Link
                     href={item.href}
                     className={cn(
-                      "flex min-h-8 items-center rounded px-2 transition sm:min-h-9 sm:px-3",
+                      "flex min-h-10 items-center rounded px-3 transition",
                       isActive
                         ? "bg-white text-slate-950"
                         : "text-white/70 hover:bg-white/10 hover:text-white",
@@ -165,9 +165,9 @@ export default function Navigation() {
               );
             })}
           </ul>
-          <div className="mx-1 hidden h-5 w-px bg-white/15 md:block" />
+          <div className="hidden h-6 w-px bg-white/15 md:block" />
           <ThemeControl value={preference} onChange={handlePreferenceChange} />
-          <div className="mx-1 h-5 w-px bg-white/15 md:hidden" />
+          <div className="h-6 w-px bg-white/15 md:hidden" />
           <button
             ref={menuButtonRef}
             type="button"
@@ -175,7 +175,7 @@ export default function Navigation() {
             aria-expanded={menuOpen}
             aria-controls={menuId}
             onClick={() => setMenuOpen((open) => !open)}
-            className="flex min-h-11 cursor-pointer items-center justify-center rounded px-3 text-white/80 transition hover:bg-white/10 hover:text-white sm:min-h-9 md:hidden"
+            className="flex min-h-12 cursor-pointer items-center justify-center rounded px-3 text-sm text-white/80 transition hover:bg-white/10 hover:text-white sm:min-h-10 md:hidden"
           >
             {menuOpen ? "Close" : "Menu"}
           </button>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,16 +5,19 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 
+import ThemeControl from "@/components/theme-control";
 import {
   LEGACY_THEME_STORAGE_KEY,
   SITE_THEME_CHANGE_EVENT,
   SITE_THEME_STORAGE_KEY,
   type SiteTheme,
+  type SiteThemePreference,
   applySiteTheme,
   isSiteTheme,
+  readStoredPreference,
   readStoredSiteTheme,
   resolveSiteTheme,
-  setStoredSiteTheme,
+  setStoredPreference,
 } from "@/lib/site-theme";
 import { NAVIGATION_ITEMS } from "#lib/config/navigation";
 import { cn } from "#lib/utils/cn";
@@ -23,6 +26,7 @@ import { isNavItemActive } from "#lib/utils/navigation";
 export default function Navigation() {
   const pathname = usePathname();
   const [theme, setTheme] = useState<SiteTheme>("hokusai");
+  const [preference, setPreference] = useState<SiteThemePreference>("system");
   const [menuOpen, setMenuOpen] = useState(false);
   const menuId = useId();
   const menuPanelRef = useRef<HTMLDivElement>(null);
@@ -31,6 +35,7 @@ export default function Navigation() {
   useEffect(() => {
     const initialTheme = resolveSiteTheme();
     setTheme(initialTheme);
+    setPreference(readStoredPreference());
     applySiteTheme(initialTheme);
 
     const handleThemeChange = (event: Event) => {
@@ -39,6 +44,7 @@ export default function Navigation() {
       if (isSiteTheme(nextTheme)) {
         setTheme(nextTheme);
       }
+      setPreference(readStoredPreference());
     };
 
     const handleStorage = (event: StorageEvent) => {
@@ -51,6 +57,7 @@ export default function Navigation() {
 
       const nextTheme = resolveSiteTheme();
       setTheme(nextTheme);
+      setPreference(readStoredPreference());
       applySiteTheme(nextTheme);
     };
 
@@ -59,6 +66,7 @@ export default function Navigation() {
       if (readStoredSiteTheme()) return;
       const nextTheme = resolveSiteTheme();
       setTheme(nextTheme);
+      setPreference(readStoredPreference());
       applySiteTheme(nextTheme);
     };
 
@@ -73,11 +81,11 @@ export default function Navigation() {
     };
   }, []);
 
-  const toggleTheme = useCallback(() => {
-    const nextTheme = theme === "twilight" ? "hokusai" : "twilight";
-    setTheme(nextTheme);
-    setStoredSiteTheme(nextTheme);
-  }, [theme]);
+  const handlePreferenceChange = useCallback((pref: SiteThemePreference) => {
+    setPreference(pref);
+    setStoredPreference(pref);
+    setTheme(resolveSiteTheme());
+  }, []);
 
   // Close the mobile menu whenever the route changes so navigating always
   // dismisses it (even when the destination is the current page).
@@ -110,7 +118,6 @@ export default function Navigation() {
     };
   }, [menuOpen]);
 
-  const nextThemeLabel = theme === "twilight" ? "day" : "night";
   const isTwilight = theme === "twilight";
   const shouldInvertLogo = isTwilight && pathname !== "/";
 
@@ -159,15 +166,8 @@ export default function Navigation() {
             })}
           </ul>
           <div className="mx-1 hidden h-5 w-px bg-white/15 md:block" />
-          <button
-            type="button"
-            aria-label={`Switch to ${nextThemeLabel} theme`}
-            title={`Switch to ${nextThemeLabel} theme`}
-            onClick={toggleTheme}
-            className="flex min-h-8 min-w-8 cursor-pointer items-center justify-center rounded text-white/80 transition hover:bg-white/10 hover:text-white sm:min-h-9 sm:min-w-9"
-          >
-            {theme === "twilight" ? <SunIcon /> : <SeaCreatureIcon />}
-          </button>
+          <ThemeControl value={preference} onChange={handlePreferenceChange} />
+          <div className="mx-1 h-5 w-px bg-white/15 md:hidden" />
           <button
             ref={menuButtonRef}
             type="button"
@@ -175,9 +175,9 @@ export default function Navigation() {
             aria-expanded={menuOpen}
             aria-controls={menuId}
             onClick={() => setMenuOpen((open) => !open)}
-            className="flex min-h-8 min-w-8 cursor-pointer items-center justify-center rounded text-white/80 transition hover:bg-white/10 hover:text-white sm:min-h-9 sm:min-w-9 md:hidden"
+            className="flex min-h-11 cursor-pointer items-center justify-center rounded px-3 text-white/80 transition hover:bg-white/10 hover:text-white sm:min-h-9 md:hidden"
           >
-            {menuOpen ? <CloseIcon /> : <MenuIcon />}
+            {menuOpen ? "Close" : "Menu"}
           </button>
         </div>
       </div>
@@ -214,82 +214,5 @@ export default function Navigation() {
         </ul>
       </div>
     </nav>
-  );
-}
-
-function SunIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-    >
-      <circle cx="12" cy="12" r="4" />
-      <path d="M12 2v2" />
-      <path d="M12 20v2" />
-      <path d="m4.93 4.93 1.41 1.41" />
-      <path d="m17.66 17.66 1.41 1.41" />
-      <path d="M2 12h2" />
-      <path d="M20 12h2" />
-      <path d="m6.34 17.66-1.41 1.41" />
-      <path d="m19.07 4.93-1.41 1.41" />
-    </svg>
-  );
-}
-
-function MenuIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-    >
-      <path d="M3 6h18" />
-      <path d="M3 12h18" />
-      <path d="M3 18h18" />
-    </svg>
-  );
-}
-
-function CloseIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-    >
-      <path d="M18 6 6 18" />
-      <path d="m6 6 12 12" />
-    </svg>
-  );
-}
-
-function SeaCreatureIcon() {
-  return (
-    <span
-      aria-hidden="true"
-      className="block h-5 w-7 bg-contain bg-center bg-no-repeat"
-      style={{
-        backgroundImage: "url('/images/tentacles-icon-swapped.png')",
-      }}
-    />
   );
 }

--- a/src/components/theme-control.tsx
+++ b/src/components/theme-control.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
+
 import type { SiteThemePreference } from "@/lib/site-theme";
 import { cn } from "#lib/utils/cn";
 
@@ -23,11 +25,30 @@ type ThemeControlProps = {
 
 /**
  * Segmented, icons-only theme control exposing all three states at once:
- * Day (light/hokusai), Auto (follow OS), Night (dark/twilight). The selected
- * segment is highlighted; the rounded-full pill sets it apart from the squared
- * nav links.
+ * Day (light/hokusai), Auto (follow OS), Night (dark/twilight). A single soft
+ * "thumb" slides behind the icons to mark the selection — low visual weight so
+ * it never pulls focus from the page. The rounded-full pill sets the grouping
+ * apart from the squared nav links.
  */
 export default function ThemeControl({ value, onChange }: ThemeControlProps) {
+  // Only morph after an actual switch, never on first paint — otherwise the
+  // control would squash itself into existence on load. We flip this the first
+  // time `value` changes from its initial selection and leave it on; the keyed
+  // fill below replays the keyframe on every subsequent change.
+  const [hasSwitched, setHasSwitched] = useState(false);
+  const previousValue = useRef(value);
+  useEffect(() => {
+    if (previousValue.current !== value) {
+      previousValue.current = value;
+      setHasSwitched(true);
+    }
+  }, [value]);
+
+  const selectedIndex = Math.max(
+    0,
+    THEME_OPTIONS.findIndex((option) => option.value === value),
+  );
+
   const moveFocus = (currentIndex: number, direction: 1 | -1) => {
     const nextIndex =
       (currentIndex + direction + THEME_OPTIONS.length) % THEME_OPTIONS.length;
@@ -38,8 +59,28 @@ export default function ThemeControl({ value, onChange }: ThemeControlProps) {
     <div
       role="radiogroup"
       aria-label="Theme"
-      className="flex items-center gap-0.5 rounded-full bg-white/5 p-0.5"
+      className="relative flex items-center rounded-full bg-white/10 p-0.5 ring-1 ring-inset ring-white/15"
     >
+      {/* Sliding selection marker. The outer element handles the glide between
+          segments; the inner fill remounts on each change (via `key`) to replay
+          the squash keyframe, so the circle stretches as it travels. */}
+      <span
+        aria-hidden="true"
+        className="theme-thumb pointer-events-none"
+        style={{
+          width: "calc((100% - 0.25rem) / 3)",
+          transform: `translateX(${selectedIndex * 100}%)`,
+        }}
+      >
+        <span
+          key={value}
+          className={cn(
+            "theme-thumb-fill",
+            hasSwitched && "theme-thumb-fill--morph",
+          )}
+        />
+      </span>
+
       {THEME_OPTIONS.map((option, index) => {
         const isSelected = option.value === value;
         return (
@@ -62,10 +103,10 @@ export default function ThemeControl({ value, onChange }: ThemeControlProps) {
               }
             }}
             className={cn(
-              "flex min-h-11 min-w-10 cursor-pointer items-center justify-center rounded-full transition sm:min-h-9",
+              "relative z-10 flex min-h-11 min-w-10 flex-1 cursor-pointer items-center justify-center rounded-full outline-none transition-colors focus-visible:ring-2 focus-visible:ring-white/40 sm:min-h-9",
               isSelected
-                ? "bg-white text-slate-950"
-                : "text-white/60 hover:text-white",
+                ? "text-white/85"
+                : "text-white/40 hover:text-white/70",
             )}
           >
             <option.Icon />

--- a/src/components/theme-control.tsx
+++ b/src/components/theme-control.tsx
@@ -59,7 +59,7 @@ export default function ThemeControl({ value, onChange }: ThemeControlProps) {
     <div
       role="radiogroup"
       aria-label="Theme"
-      className="relative flex items-center rounded-full bg-white/10 p-0.5 ring-1 ring-inset ring-white/15"
+      className="relative flex items-center rounded bg-white/10 p-0.5 ring-1 ring-inset ring-white/15"
     >
       {/* Sliding selection marker. The outer element handles the glide between
           segments; the inner fill remounts on each change (via `key`) to replay
@@ -103,7 +103,7 @@ export default function ThemeControl({ value, onChange }: ThemeControlProps) {
               }
             }}
             className={cn(
-              "relative z-10 flex min-h-11 min-w-10 flex-1 cursor-pointer items-center justify-center rounded-full outline-none transition-colors focus-visible:ring-2 focus-visible:ring-white/40 sm:min-h-9",
+              "relative z-10 flex min-h-12 min-w-9 flex-1 cursor-pointer items-center justify-center rounded-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-white/40 sm:min-h-10 sm:min-w-10",
               isSelected
                 ? "text-white/85"
                 : "text-white/40 hover:text-white/70",

--- a/src/components/theme-control.tsx
+++ b/src/components/theme-control.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import type { SiteThemePreference } from "@/lib/site-theme";
+import { cn } from "#lib/utils/cn";
+
+type ThemeOption = {
+  value: SiteThemePreference;
+  label: string;
+  Icon: () => React.ReactElement;
+};
+
+// Order reads sun -> eye -> deep: Day, Auto, Night.
+const THEME_OPTIONS: ThemeOption[] = [
+  { value: "hokusai", label: "Day", Icon: SunIcon },
+  { value: "system", label: "Auto", Icon: EyeIcon },
+  { value: "twilight", label: "Night", Icon: SeaCreatureIcon },
+];
+
+type ThemeControlProps = {
+  value: SiteThemePreference;
+  onChange: (pref: SiteThemePreference) => void;
+};
+
+/**
+ * Segmented, icons-only theme control exposing all three states at once:
+ * Day (light/hokusai), Auto (follow OS), Night (dark/twilight). The selected
+ * segment is highlighted; the rounded-full pill sets it apart from the squared
+ * nav links.
+ */
+export default function ThemeControl({ value, onChange }: ThemeControlProps) {
+  const moveFocus = (currentIndex: number, direction: 1 | -1) => {
+    const nextIndex =
+      (currentIndex + direction + THEME_OPTIONS.length) % THEME_OPTIONS.length;
+    onChange(THEME_OPTIONS[nextIndex].value);
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Theme"
+      className="flex items-center gap-0.5 rounded-full bg-white/5 p-0.5"
+    >
+      {THEME_OPTIONS.map((option, index) => {
+        const isSelected = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            aria-label={option.label}
+            title={option.label}
+            tabIndex={isSelected ? 0 : -1}
+            onClick={() => onChange(option.value)}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+                event.preventDefault();
+                moveFocus(index, 1);
+              } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+                event.preventDefault();
+                moveFocus(index, -1);
+              }
+            }}
+            className={cn(
+              "flex min-h-11 min-w-10 cursor-pointer items-center justify-center rounded-full transition sm:min-h-9",
+              isSelected
+                ? "bg-white text-slate-950"
+                : "text-white/60 hover:text-white",
+            )}
+          >
+            <option.Icon />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2" />
+      <path d="M12 20v2" />
+      <path d="m4.93 4.93 1.41 1.41" />
+      <path d="m17.66 17.66 1.41 1.41" />
+      <path d="M2 12h2" />
+      <path d="M20 12h2" />
+      <path d="m6.34 17.66-1.41 1.41" />
+      <path d="m19.07 4.93-1.41 1.41" />
+    </svg>
+  );
+}
+
+// Auto = a single watching eye: "the deep decides." Inherits the segment color
+// via currentColor so it reads on both selected and unselected states.
+function EyeIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="17"
+      height="17"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    >
+      <path d="M2 12c2.5-4.5 6-6.75 10-6.75S19.5 7.5 22 12c-2.5 4.5-6 6.75-10 6.75S4.5 16.5 2 12Z" />
+      <circle cx="12" cy="12" r="2.75" />
+    </svg>
+  );
+}
+
+function SeaCreatureIcon() {
+  return (
+    <span
+      aria-hidden="true"
+      className="block h-5 w-7 bg-contain bg-center bg-no-repeat"
+      style={{
+        backgroundImage: "url('/images/tentacles-icon-swapped.png')",
+      }}
+    />
+  );
+}

--- a/src/components/theme-control.tsx
+++ b/src/components/theme-control.tsx
@@ -103,7 +103,7 @@ export default function ThemeControl({ value, onChange }: ThemeControlProps) {
               }
             }}
             className={cn(
-              "relative z-10 flex min-h-12 min-w-9 flex-1 cursor-pointer items-center justify-center rounded-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-white/40 sm:min-h-10 sm:min-w-10",
+              "relative z-10 flex min-h-12 min-w-12 flex-1 cursor-pointer items-center justify-center rounded-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-white/40 sm:min-h-10 sm:min-w-10",
               isSelected
                 ? "text-white/85"
                 : "text-white/40 hover:text-white/70",

--- a/src/lib/site-theme.ts
+++ b/src/lib/site-theme.ts
@@ -1,11 +1,25 @@
 export type SiteTheme = "hokusai" | "twilight";
 
+/**
+ * What the visitor explicitly chose. `"system"` means "follow the OS" — it is
+ * deliberately *not* a `SiteTheme` (the resolved value applied to the DOM is
+ * always `hokusai`/`twilight`). This tri-state drives the segmented theme
+ * control; the DOM/event contract still only ever sees a resolved `SiteTheme`.
+ */
+export type SiteThemePreference = "system" | "hokusai" | "twilight";
+
 export const SITE_THEME_STORAGE_KEY = "jasonmakes:theme";
 export const LEGACY_THEME_STORAGE_KEY = "jasonmakes:home-theme";
 export const SITE_THEME_CHANGE_EVENT = "jasonmakes:theme-change";
 
 export function isSiteTheme(value: string | null): value is SiteTheme {
   return value === "hokusai" || value === "twilight";
+}
+
+export function isSiteThemePreference(
+  value: string | null,
+): value is SiteThemePreference {
+  return value === "system" || value === "hokusai" || value === "twilight";
 }
 
 export function getSystemSiteTheme(): SiteTheme {
@@ -54,13 +68,51 @@ export function applySiteTheme(theme: SiteTheme) {
     theme === "twilight" ? "dark" : "light";
 }
 
-export function setStoredSiteTheme(theme: SiteTheme) {
-  window.localStorage.setItem(SITE_THEME_STORAGE_KEY, theme);
-  window.localStorage.setItem(LEGACY_THEME_STORAGE_KEY, theme);
-  applySiteTheme(theme);
+/**
+ * Read the visitor's explicit preference for the segmented theme control.
+ *
+ * Unlike `readStoredSiteTheme` (which returns a resolved `SiteTheme` or `null`),
+ * this surfaces the tri-state choice: an explicit `hokusai`/`twilight`, the
+ * literal `"system"` (follow the OS), or — when nothing valid is stored — a
+ * default of `"system"`. A prior legacy explicit choice migrates to that same
+ * explicit Day/Night selection.
+ */
+export function readStoredPreference(): SiteThemePreference {
+  if (typeof window === "undefined") return "system";
+
+  const stored = window.localStorage.getItem(SITE_THEME_STORAGE_KEY);
+  if (isSiteThemePreference(stored)) return stored;
+
+  const legacy = window.localStorage.getItem(LEGACY_THEME_STORAGE_KEY);
+  if (isSiteThemePreference(legacy)) return legacy;
+
+  return "system";
+}
+
+/**
+ * Persist the visitor's explicit preference, apply the resolved theme to the
+ * DOM, and broadcast the change. The event/DOM always carry a resolved
+ * `SiteTheme`; `"system"` resolves to the current OS theme at write time, while
+ * the literal `"system"` string is stored so cross-tab `storage` sync and the
+ * segmented selection stay explicit. (`isSiteTheme` still treats `"system"` as
+ * "no explicit theme", so the `matchMedia` listeners keep live-updating.)
+ */
+export function setStoredPreference(pref: SiteThemePreference) {
+  const resolved = pref === "system" ? getSystemSiteTheme() : pref;
+  window.localStorage.setItem(SITE_THEME_STORAGE_KEY, pref);
+  window.localStorage.setItem(LEGACY_THEME_STORAGE_KEY, pref);
+  applySiteTheme(resolved);
   window.dispatchEvent(
     new CustomEvent<{ theme: SiteTheme }>(SITE_THEME_CHANGE_EVENT, {
-      detail: { theme },
+      detail: { theme: resolved },
     }),
   );
+}
+
+/**
+ * Persist an explicit resolved theme. Thin wrapper over `setStoredPreference`
+ * kept so existing callers (e.g. the homepage seascape switcher) stay working.
+ */
+export function setStoredSiteTheme(theme: SiteTheme) {
+  setStoredPreference(theme);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": resolve(__dirname, "./"),
+      // Mirror the tsconfig "#lib/*" -> "./lib/*" subpath so component tests can
+      // resolve imports like "#lib/utils/cn".
+      "#lib": resolve(__dirname, "./lib"),
     },
   },
 });


### PR DESCRIPTION
Replace the binary light/dark toggle with an explicit three-state
segmented control (Day / Auto / Night) so visitors can choose to follow
their OS color scheme instead of being locked into a manual choice once
they toggle. The control is always visible in the top bar on both mobile
and desktop.

- site-theme: add a SiteThemePreference tri-state ("system" | "hokusai" |
  "twilight") with readStoredPreference/setStoredPreference. The DOM and
  theme-change event still only ever carry a resolved SiteTheme; "system"
  resolves to the OS theme at write time. setStoredSiteTheme is kept as a
  thin wrapper so the homepage seascape switcher is unaffected.
- theme-control: new icons-only segmented radiogroup. Day = sun,
  Night = the existing tentacle/sea-creature glyph, Auto = a watching eye.
  Arrow-key navigation and 44px touch targets on mobile.
- Navigation: track the preference alongside the resolved theme, keep it
  in sync across tabs / system changes, and replace the hamburger with a
  "Menu"/"Close" text button sized as a proper touch target.
- layout: clarify that a stored "system" preference falls through to the
  OS theme in the anti-FOUC init script.
- vitest: resolve the "#lib" subpath alias so component tests can import
  shared utils.

https://claude.ai/code/session_01NHEjsCYgSxsgnWXqAzHcLk