### PR TITLE
Update About body copy and homepage dispatch explainer

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -37,11 +37,11 @@ export default function AboutPage() {
               people fast, and being honest about whether it actually helped.
             </p>
             <p>
-              The craft underneath still matters to me: heuristic evaluation,
-              information architecture, design systems, the quiet scaffolding
-              that makes the next decision easier. Good work doesn't erase
-              complexity so much as organize it, so the people I build for can
-              make confident choices.
+              The craft underneath still matters to me a lot. Heuristic
+              evaluation, information architecture, design systems, the quiet
+              scaffolding that makes the next decision easier. Good work doesn't
+              erase complexity so much as organize it, so the people I build for
+              can make confident choices.
             </p>
             <p>
               That's the work at Standard Education, where we turn K-12
@@ -56,8 +56,7 @@ export default function AboutPage() {
               >
                 FullStory
               </a>
-              , rebuilt the survey-export experience at Glass for research teams
-              at brands like Unilever and Clorox, and shaped product strategy at{" "}
+              , ran{" "}
               <a
                 href="https://signallantern.com"
                 target="_blank"
@@ -65,8 +64,10 @@ export default function AboutPage() {
                 className="text-[var(--u-accent)] underline decoration-1 underline-offset-4 transition-colors hover:text-[var(--u-accent-strong)]"
               >
                 Signal Lantern
-              </a>
-              .
+              </a>{" "}
+              where I rebuilt the survey-export experience at Glass for research
+              teams at brands like Unilever and Clorox, and led a development
+              team and facilitated Design Sprints at Three Five Two.
             </p>
             <p className="font-[family-name:var(--font-instrument-serif)] text-xl italic text-[var(--u-ink-strong)]">
               This site is a small experiment in that idea: a calm surface over

--- a/src/app/components/DailyProfileOverlay.tsx
+++ b/src/app/components/DailyProfileOverlay.tsx
@@ -219,9 +219,10 @@ export default async function DailyProfileOverlay() {
     <DailyProfilePanel blurb={blurb}>
       <div className="daily-profile-explainer">
         <p>
-          This panel runs on its own. Atlanta weather, the last track Jason
-          played, and the latest things he saved to read update through the day.
-          The short dispatch on the glass is generated from those same signals.
+          This panel runs on its own (which is why it's in third person). What
+          you see is made up of the last track I played on Spotify, the weather
+          in my city, and what I'm currently reading in my news feed, updated
+          hourly. The short dispatch above is generated from these same signals.
         </p>
       </div>
 


### PR DESCRIPTION
- Rework About craft paragraph and rewrite work history (reposition
  Signal Lantern link, add Three Five Two); fix quiet typo
- Rewrite Below the surface dispatch explainer in first person

https://claude.ai/code/session_01Xe7UDg4dd9UhZD3urE6WQJ