### PR TITLE
Add Spotify album art to the Music card

### DIFF
--- a/src/app/components/DailyProfileOverlay.tsx
+++ b/src/app/components/DailyProfileOverlay.tsx
@@ -113,36 +113,38 @@ function MusicSignal({
 
   return (
     <section className="daily-profile-signal">
-      <div>
-        <p className="daily-profile-signal__label">Music</p>
-        <h3>Recently played</h3>
-      </div>
-      <div className="daily-profile-track">
-        <div className="daily-profile-track__copy">
-          <p className="daily-profile-signal__value">{track.title}</p>
-          <p className="daily-profile-signal__meta">by {track.artist}</p>
-          {track.trackUrl && (
-            <a
-              href={track.trackUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="daily-profile-link"
-            >
-              Listen on Spotify
-            </a>
+      <div className="daily-profile-music">
+        <div className="daily-profile-music__copy">
+          <div>
+            <p className="daily-profile-signal__label">Music</p>
+            <h3>Recently played</h3>
+          </div>
+          <div className="daily-profile-track">
+            <p className="daily-profile-signal__value">{track.title}</p>
+            <p className="daily-profile-signal__meta">by {track.artist}</p>
+            {track.trackUrl && (
+              <a
+                href={track.trackUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="daily-profile-link"
+              >
+                Listen on Spotify
+              </a>
+            )}
+          </div>
+          {spotify?.lastUpdated && (
+            <p className="daily-profile-updated">
+              Updated {formatUpdatedAt(spotify.lastUpdated)}
+            </p>
           )}
         </div>
         {track.coverUrl && (
-          <span className="daily-profile-track__art" aria-hidden="true">
+          <span className="daily-profile-music__art" aria-hidden="true">
             <img src={track.coverUrl} alt="" loading="lazy" />
           </span>
         )}
       </div>
-      {spotify?.lastUpdated && (
-        <p className="daily-profile-updated">
-          Updated {formatUpdatedAt(spotify.lastUpdated)}
-        </p>
-      )}
     </section>
   );
 }

--- a/src/app/components/DailyProfileOverlay.tsx
+++ b/src/app/components/DailyProfileOverlay.tsx
@@ -118,17 +118,24 @@ function MusicSignal({
         <h3>Recently played</h3>
       </div>
       <div className="daily-profile-track">
-        <p className="daily-profile-signal__value">{track.title}</p>
-        <p className="daily-profile-signal__meta">by {track.artist}</p>
-        {track.trackUrl && (
-          <a
-            href={track.trackUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="daily-profile-link"
-          >
-            Listen on Spotify
-          </a>
+        <div className="daily-profile-track__copy">
+          <p className="daily-profile-signal__value">{track.title}</p>
+          <p className="daily-profile-signal__meta">by {track.artist}</p>
+          {track.trackUrl && (
+            <a
+              href={track.trackUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="daily-profile-link"
+            >
+              Listen on Spotify
+            </a>
+          )}
+        </div>
+        {track.coverUrl && (
+          <span className="daily-profile-track__art" aria-hidden="true">
+            <img src={track.coverUrl} alt="" loading="lazy" />
+          </span>
         )}
       </div>
       {spotify?.lastUpdated && (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -327,7 +327,6 @@ body {
 
 .daily-profile-dialog[data-visible="true"] .daily-profile-dialog__inner {
   overflow: visible;
-  padding-bottom: 1.2rem;
 }
 
 .daily-profile-dialog__header {
@@ -354,6 +353,11 @@ body {
   margin-top: 1rem;
   display: grid;
   gap: 1rem;
+  /* The dialog is a grid scroll container; its own padding-bottom (and that of
+     the stretched __inner) is dropped at scroll-end. Put the bottom gap on the
+     actual overflowing content so it's included in the scrollable area and the
+     last card doesn't touch the panel edge on desktop. */
+  padding-bottom: 1.2rem;
 }
 
 .daily-profile-explainer {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -410,6 +410,36 @@ body {
   align-items: flex-start;
 }
 
+.daily-profile-track {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.daily-profile-track__copy {
+  min-width: 0;
+}
+
+.daily-profile-track__art {
+  display: block;
+  flex-shrink: 0;
+  width: 4rem;
+  height: 4rem;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--u-panel-border) 42%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--u-bg-0) 58%, var(--u-bg-1));
+}
+
+.daily-profile-track__art img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.88) contrast(0.96);
+}
+
 .daily-profile-weather__mark {
   display: inline-flex;
   min-width: 2.25rem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -410,29 +410,33 @@ body {
   align-items: flex-start;
 }
 
-.daily-profile-track {
+.daily-profile-music {
   display: flex;
-  gap: 0.75rem;
+  gap: clamp(0.85rem, 3%, 1.4rem);
   align-items: flex-start;
-  justify-content: space-between;
 }
 
-.daily-profile-track__copy {
-  min-width: 0;
+/* Left column sizes to fill remaining space but never shrinks below the
+   widest fixed line ("UPDATED MON 00, 00:00 PM EDT") so that copy never wraps;
+   the album art takes the rest and gives way first when space is tight. */
+.daily-profile-music__copy {
+  flex: 1 1 0;
+  min-width: min(100%, 11.75rem);
 }
 
-.daily-profile-track__art {
-  display: block;
-  flex-shrink: 0;
-  width: 4rem;
-  height: 4rem;
+.daily-profile-music__art {
+  flex: 0 1 auto;
+  align-self: flex-start;
+  width: 46%;
+  max-width: 12rem;
+  aspect-ratio: 1 / 1;
   overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--u-panel-border) 42%, transparent);
   border-radius: 8px;
   background: color-mix(in srgb, var(--u-bg-0) 58%, var(--u-bg-1));
 }
 
-.daily-profile-track__art img {
+.daily-profile-music__art img {
   display: block;
   width: 100%;
   height: 100%;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -311,7 +311,10 @@ body {
   overflow-y: auto;
   border-top-color: color-mix(in srgb, var(--u-panel-border) 78%, white 22%);
   opacity: 1;
-  padding-block: 1rem 1.2rem;
+  /* Bottom gap lives on the scrolled child (__inner) instead of here: a grid
+     scroll container's own padding-bottom is dropped at scroll-end in Chromium,
+     which made the last card touch the panel edge on desktop. */
+  padding-block: 1rem 0;
   pointer-events: auto;
   transform: none;
   transition-delay: 0ms, 80ms, 0ms, 0ms, 0ms;
@@ -324,6 +327,7 @@ body {
 
 .daily-profile-dialog[data-visible="true"] .daily-profile-dialog__inner {
   overflow: visible;
+  padding-bottom: 1.2rem;
 }
 
 .daily-profile-dialog__header {


### PR DESCRIPTION
The recently-played album cover was already fetched and stored in KV via
the Spotify provider (coverUrl) but never displayed. Render it on the right
side of the Music card in the daily-profile panel, matching the plain-img
pattern used by the reading thumbnails.