### PR TITLE
Animate daily profile intro on first paint instead of after hydration

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,9 +71,11 @@ body {
   /* Intro runs as a CSS animation so it plays on first paint—while the page is
      still loading—instead of waiting for React to hydrate before fading in. The
      panel surfaces from below the waterline: it rises blurred and desaturated
-     (as if underwater), crests just past its resting line like a swell, then
-     bobs into place with a damped settle. The 300ms delay holds it under. */
-  animation: daily-profile-surface 2000ms cubic-bezier(0.16, 0.84, 0.34, 1) 300ms
+     (as if underwater), crests its resting line like a swell, then rides a long,
+     low, slowly-damping roll—crossing the line several times so it's hard to
+     tell when it finally stills, like settling at sea. 300ms delay holds it
+     under first. */
+  animation: daily-profile-surface 3600ms cubic-bezier(0.16, 0.84, 0.34, 1) 300ms
     both;
   transition: width 640ms cubic-bezier(0.19, 1, 0.22, 1);
 }
@@ -86,22 +88,30 @@ body {
     /* buoyant rise toward the surface, decelerating as it crests */
     animation-timing-function: cubic-bezier(0.16, 0.84, 0.34, 1);
   }
-  45% {
+  33% {
     opacity: 1;
     filter: blur(0) saturate(1);
-    /* crest just above the resting line, like the top of a swell */
-    transform: translate3d(0, -9px, 0) scale(1.006);
-    /* sine ease for each leg of the bob so it reads like water, not a glide */
+    /* crest its resting line, like the top of a swell (scale has settled,
+       so the roll is pure vertical drift—no pulse, no bounce) */
+    transform: translate3d(0, -5px, 0);
+    /* sine ease on every leg so each crossing rolls like water, not a glide */
     animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
-  68% {
-    /* dip just past rest, the way a buoy dunks before settling */
-    transform: translate3d(0, 5px, 0);
+  49% {
+    transform: translate3d(0, 3px, 0);
     animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
-  86% {
-    /* smaller rebound above the line as the bob decays */
-    transform: translate3d(0, -2px, 0);
+  64% {
+    transform: translate3d(0, -1.8px, 0);
+    animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
+  }
+  77% {
+    transform: translate3d(0, 1px, 0);
+    animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
+  }
+  89% {
+    /* the last crossing is barely perceptible—the sea going still */
+    transform: translate3d(0, -0.5px, 0);
     animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
   to {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,24 +67,24 @@ body {
   z-index: 40;
   width: min(30rem, calc(100vw - 2rem));
   color: var(--u-ink);
-  filter: blur(5px) saturate(0.92);
-  opacity: 0;
   pointer-events: none;
-  transform: translate3d(0, 26px, 0) scale(0.985);
-  transition: opacity 1900ms cubic-bezier(0.19, 1, 0.22, 1), filter 1900ms
-    cubic-bezier(0.19, 1, 0.22, 1), transform 1900ms
-    cubic-bezier(0.19, 1, 0.22, 1), width 640ms
-    cubic-bezier(0.19, 1, 0.22, 1);
+  /* Intro runs as a CSS animation so it plays on first paint—while the page is
+     still loading—instead of waiting for React to hydrate before fading in. */
+  animation: daily-profile-intro 1900ms cubic-bezier(0.19, 1, 0.22, 1) both;
+  transition: width 640ms cubic-bezier(0.19, 1, 0.22, 1);
 }
 
-.daily-profile-shell[data-ready="true"] {
-  filter: blur(0) saturate(1);
-  opacity: 1;
-  transform: none;
-}
-
-.daily-profile-shell[data-entered="true"] {
-  transition: filter 220ms ease, width 640ms cubic-bezier(0.19, 1, 0.22, 1);
+@keyframes daily-profile-intro {
+  from {
+    filter: blur(5px) saturate(0.92);
+    opacity: 0;
+    transform: translate3d(0, 26px, 0) scale(0.985);
+  }
+  to {
+    filter: blur(0) saturate(1);
+    opacity: 1;
+    transform: none;
+  }
 }
 
 .daily-profile-shell[data-open="true"] {
@@ -735,6 +735,10 @@ body {
   .daily-profile-link,
   .daily-profile-read-card {
     transition: none;
+  }
+
+  .daily-profile-shell {
+    animation: none;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -70,20 +70,31 @@ body {
   pointer-events: none;
   /* Intro runs as a CSS animation so it plays on first paint—while the page is
      still loading—instead of waiting for React to hydrate before fading in. The
-     short delay holds the hidden state briefly before the reveal begins. */
-  animation: daily-profile-intro 1900ms cubic-bezier(0.19, 1, 0.22, 1) 300ms both;
+     panel surfaces from below the waterline: it rises blurred and desaturated
+     (as if underwater), crests just past its resting line like a swell, then
+     ebbs back down and settles. The 300ms delay holds it under before the rise. */
+  animation: daily-profile-surface 1500ms cubic-bezier(0.16, 0.84, 0.34, 1) 300ms
+    both;
   transition: width 640ms cubic-bezier(0.19, 1, 0.22, 1);
 }
 
-@keyframes daily-profile-intro {
+@keyframes daily-profile-surface {
   from {
-    filter: blur(5px) saturate(0.92);
     opacity: 0;
-    transform: translate3d(0, 26px, 0) scale(0.985);
+    filter: blur(6px) saturate(0.86);
+    transform: translate3d(0, 32px, 0) scale(0.98);
+    /* buoyant rise toward the surface, decelerating as it crests */
+    animation-timing-function: cubic-bezier(0.16, 0.84, 0.34, 1);
+  }
+  62% {
+    opacity: 1;
+    filter: blur(0) saturate(1);
+    /* crest just above the resting line */
+    transform: translate3d(0, -6px, 0) scale(1.005);
+    /* calm ebb back down to rest */
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   }
   to {
-    filter: blur(0) saturate(1);
-    opacity: 1;
     transform: none;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,7 +73,7 @@ body {
      panel surfaces from below the waterline: it rises blurred and desaturated
      (as if underwater), crests just past its resting line like a swell, then
      bobs into place with a damped settle. The 300ms delay holds it under. */
-  animation: daily-profile-surface 1500ms cubic-bezier(0.16, 0.84, 0.34, 1) 300ms
+  animation: daily-profile-surface 2000ms cubic-bezier(0.16, 0.84, 0.34, 1) 300ms
     both;
   transition: width 640ms cubic-bezier(0.19, 1, 0.22, 1);
 }
@@ -86,22 +86,22 @@ body {
     /* buoyant rise toward the surface, decelerating as it crests */
     animation-timing-function: cubic-bezier(0.16, 0.84, 0.34, 1);
   }
-  55% {
+  45% {
     opacity: 1;
     filter: blur(0) saturate(1);
     /* crest just above the resting line, like the top of a swell */
-    transform: translate3d(0, -6px, 0) scale(1.005);
+    transform: translate3d(0, -9px, 0) scale(1.006);
     /* sine ease for each leg of the bob so it reads like water, not a glide */
     animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
-  73% {
+  68% {
     /* dip just past rest, the way a buoy dunks before settling */
-    transform: translate3d(0, 3px, 0);
+    transform: translate3d(0, 5px, 0);
     animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
-  88% {
+  86% {
     /* smaller rebound above the line as the bob decays */
-    transform: translate3d(0, -1.5px, 0);
+    transform: translate3d(0, -2px, 0);
     animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
   to {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -72,7 +72,7 @@ body {
      still loading—instead of waiting for React to hydrate before fading in. The
      panel surfaces from below the waterline: it rises blurred and desaturated
      (as if underwater), crests just past its resting line like a swell, then
-     ebbs back down and settles. The 300ms delay holds it under before the rise. */
+     bobs into place with a damped settle. The 300ms delay holds it under. */
   animation: daily-profile-surface 1500ms cubic-bezier(0.16, 0.84, 0.34, 1) 300ms
     both;
   transition: width 640ms cubic-bezier(0.19, 1, 0.22, 1);
@@ -86,13 +86,23 @@ body {
     /* buoyant rise toward the surface, decelerating as it crests */
     animation-timing-function: cubic-bezier(0.16, 0.84, 0.34, 1);
   }
-  62% {
+  55% {
     opacity: 1;
     filter: blur(0) saturate(1);
-    /* crest just above the resting line */
+    /* crest just above the resting line, like the top of a swell */
     transform: translate3d(0, -6px, 0) scale(1.005);
-    /* calm ebb back down to rest */
-    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    /* sine ease for each leg of the bob so it reads like water, not a glide */
+    animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
+  }
+  73% {
+    /* dip just past rest, the way a buoy dunks before settling */
+    transform: translate3d(0, 3px, 0);
+    animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
+  }
+  88% {
+    /* smaller rebound above the line as the bob decays */
+    transform: translate3d(0, -1.5px, 0);
+    animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
   to {
     transform: none;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -69,8 +69,9 @@ body {
   color: var(--u-ink);
   pointer-events: none;
   /* Intro runs as a CSS animation so it plays on first paint—while the page is
-     still loading—instead of waiting for React to hydrate before fading in. */
-  animation: daily-profile-intro 1900ms cubic-bezier(0.19, 1, 0.22, 1) both;
+     still loading—instead of waiting for React to hydrate before fading in. The
+     short delay holds the hidden state briefly before the reveal begins. */
+  animation: daily-profile-intro 1900ms cubic-bezier(0.19, 1, 0.22, 1) 300ms both;
   transition: width 640ms cubic-bezier(0.19, 1, 0.22, 1);
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,7 +75,7 @@ body {
      low, slowly-damping roll—crossing the line several times so it's hard to
      tell when it finally stills, like settling at sea. 300ms delay holds it
      under first. */
-  animation: daily-profile-surface 3600ms cubic-bezier(0.16, 0.84, 0.34, 1) 300ms
+  animation: daily-profile-surface 4000ms cubic-bezier(0.16, 0.84, 0.34, 1) 300ms
     both;
   transition: width 640ms cubic-bezier(0.19, 1, 0.22, 1);
 }
@@ -84,38 +84,42 @@ body {
   from {
     opacity: 0;
     filter: blur(6px) saturate(0.86);
-    transform: translate3d(0, 32px, 0) scale(0.98);
+    transform: translate3d(0, 32px, 0) scale(0.98) rotate(0deg);
     /* buoyant rise toward the surface, decelerating as it crests */
     animation-timing-function: cubic-bezier(0.16, 0.84, 0.34, 1);
   }
   33% {
     opacity: 1;
     filter: blur(0) saturate(1);
-    /* crest its resting line, like the top of a swell (scale has settled,
-       so the roll is pure vertical drift—no pulse, no bounce) */
-    transform: translate3d(0, -5px, 0);
+    /* crest its resting line, level and centered—the lateral roll only
+       begins once it's surfaced, so the entrance stays a clean vertical */
+    transform: translate3d(0, -5px, 0) scale(1) rotate(0deg);
     /* sine ease on every leg so each crossing rolls like water, not a glide */
     animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
+  /* Vertical bobs ~2.5 times; the horizontal drift swings just once (right,
+     then left) over the same span, so the two run out of phase and trace a
+     slow ellipse instead of a diagonal. The micro-roll leans into the drift,
+     like a hull listing, and everything decays to dead level by 100%. */
   49% {
-    transform: translate3d(0, 3px, 0);
+    transform: translate3d(2.2px, 3px, 0) scale(1) rotate(0.3deg);
     animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
   64% {
-    transform: translate3d(0, -1.8px, 0);
+    transform: translate3d(0.4px, -1.8px, 0) scale(1) rotate(0.05deg);
     animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
   77% {
-    transform: translate3d(0, 1px, 0);
+    transform: translate3d(-1.4px, 1px, 0) scale(1) rotate(-0.2deg);
     animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
   89% {
     /* the last crossing is barely perceptible—the sea going still */
-    transform: translate3d(0, -0.5px, 0);
+    transform: translate3d(-0.4px, -0.5px, 0) scale(1) rotate(-0.05deg);
     animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
   }
   to {
-    transform: none;
+    transform: translate3d(0, 0, 0) scale(1) rotate(0deg);
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,7 +75,7 @@ body {
      low, slowly-damping roll—crossing the line several times so it's hard to
      tell when it finally stills, like settling at sea. 300ms delay holds it
      under first. */
-  animation: daily-profile-surface 4000ms cubic-bezier(0.16, 0.84, 0.34, 1) 300ms
+  animation: daily-profile-surface 8000ms cubic-bezier(0.16, 0.84, 0.34, 1) 300ms
     both;
   transition: width 640ms cubic-bezier(0.19, 1, 0.22, 1);
 }


### PR DESCRIPTION
The panel's fade/blur/slide-in was triggered by JS flipping data-ready
inside a useEffect, which only runs after React hydrates—so the intro
started after the page finished loading. Drive the reveal with a CSS
@keyframes animation that auto-plays on first paint, so it runs while
the page is still loading.